### PR TITLE
feat(thinking): add extended thinking blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ app.route("/", createAgentRouter({ sessions, translator }));
 serve({ fetch: app.fetch, port: 3000 });
 ```
 
+### Extended thinking
+
+Enable Claude's chain-of-thought reasoning by setting `thinking` in your session config:
+
+```typescript
+const sessions = new SessionManager(() => ({
+  context: {},
+  model: "claude-sonnet-4-5-20250929",
+  systemPrompt: "You are a helpful assistant.",
+  thinking: { type: "enabled", budgetTokens: 10000 },
+}));
+```
+
+When enabled, thinking blocks stream to the client as `thinking_delta` SSE events and render as collapsible cards in `MessageList`. Set `{ type: "disabled" }` to explicitly turn thinking off (it's off by default).
+
 This gives you four endpoints:
 
 | Method | Path | Description |
@@ -338,6 +353,7 @@ Drop the `fireworks-ai/theme.css` import and add `@source` — your shadcn theme
 | `PendingPermissions` | Renders pending tool approval and user question cards |
 | `ToolApprovalCard` | Tool approval card with Allow/Deny buttons |
 | `UserQuestionCard` | Structured question card with option selection |
+| `ThinkingBlock` | Collapsible card displaying extended thinking text |
 | `ThinkingIndicator` | Animated dots shown while agent is generating |
 | `CollapsibleCard` | Expandable card wrapper |
 | `StatusDot` | Phase-colored status indicator |
@@ -351,7 +367,7 @@ Drop the `fireworks-ai/theme.css` import and add `@source` — your shadcn theme
 | Type | Description |
 |------|-------------|
 | `SSEEvent` | `{ event: string, data: string }` |
-| `ChatMessage` | `{ id, role, content, toolCalls? }` |
+| `ChatMessage` | `{ id, role, content, thinking?, toolCalls? }` |
 | `ToolCallInfo` | `{ id, name, input, partialInput?, result?, error?, status }` |
 | `ToolCallPhase` | `"pending" \| "streaming_input" \| "running" \| "complete" \| "error"` |
 | `WidgetProps<TResult>` | Props passed to widget components |
@@ -374,6 +390,8 @@ Events emitted by the server, handled automatically by `useAgent`:
 | Event | Payload | Description |
 |-------|---------|-------------|
 | `message_start` | `{}` | Agent began generating a response |
+| `thinking_start` | `{}` | Extended thinking block began |
+| `thinking_delta` | `{ text }` | Streaming thinking text chunk |
 | `text_delta` | `{ text }` | Streaming text chunk |
 | `tool_start` | `{ id, name }` | Agent began calling a tool |
 | `tool_input_delta` | `{ id, partialJson }` | Streaming tool input JSON |

--- a/src/react/ChatInput.tsx
+++ b/src/react/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useState } from "react";
+import { type KeyboardEvent, useCallback, useRef, useState } from "react";
 import { cn } from "./cn.js";
 
 export function ChatInput({
@@ -13,13 +13,30 @@ export function ChatInput({
   className?: string;
 }) {
   const [text, setText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isDisabled = disabled ?? false;
+
+  const MAX_H = 160; // matches max-h-40 (10rem)
+
+  const autoResize = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+    el.style.overflowY = el.scrollHeight > MAX_H ? "auto" : "hidden";
+  }, []);
 
   function handleSend() {
     const trimmed = text.trim();
     if (!trimmed || isDisabled) return;
     onSend(trimmed);
     setText("");
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (el) {
+        el.style.height = "auto";
+      }
+    });
   }
 
   function handleKeyDown(e: KeyboardEvent) {
@@ -32,12 +49,16 @@ export function ChatInput({
   return (
     <div className={cn("flex items-end gap-2 p-3", className)}>
       <textarea
+        ref={textareaRef}
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e) => {
+          setText(e.target.value);
+          autoResize();
+        }}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         rows={1}
-        className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-h-40 overflow-y-hidden"
       />
       <button
         type="button"

--- a/src/react/MessageList.tsx
+++ b/src/react/MessageList.tsx
@@ -3,19 +3,21 @@ import { useChatStore } from "./AgentProvider.js";
 import { cn } from "./cn.js";
 import { PendingPermissions } from "./PendingPermissions.js";
 import { TextMessage } from "./TextMessage.js";
+import { ThinkingBlock } from "./ThinkingBlock.js";
 import { ThinkingIndicator } from "./ThinkingIndicator.js";
 import { ToolCallCard } from "./ToolCallCard.js";
 
 export function MessageList({ className }: { className?: string }) {
   const messages = useChatStore((s) => s.messages);
   const streamingText = useChatStore((s) => s.streamingText);
+  const streamingThinking = useChatStore((s) => s.streamingThinking);
   const isThinking = useChatStore((s) => s.isThinking);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on content changes
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, streamingText, isThinking]);
+  }, [messages, streamingText, streamingThinking, isThinking]);
 
   return (
     <div className={cn("flex-1 overflow-y-auto", className)}>
@@ -37,17 +39,19 @@ export function MessageList({ className }: { className?: string }) {
               </div>
             );
           }
-          if (msg.content) {
+          if (msg.content || msg.thinking) {
             return (
-              <TextMessage
-                key={msg.id}
-                role={msg.role as "user" | "assistant"}
-                content={msg.content}
-              />
+              <div key={msg.id} className="flex flex-col gap-1.5">
+                {msg.thinking && <ThinkingBlock thinking={msg.thinking} />}
+                {msg.content && (
+                  <TextMessage role={msg.role as "user" | "assistant"} content={msg.content} />
+                )}
+              </div>
             );
           }
           return null;
         })}
+        {streamingThinking && <ThinkingBlock thinking={streamingThinking} streaming />}
         {streamingText && <TextMessage role="assistant" content={streamingText} />}
         <PendingPermissions />
         {isThinking && <ThinkingIndicator />}

--- a/src/react/ThinkingBlock.tsx
+++ b/src/react/ThinkingBlock.tsx
@@ -1,0 +1,94 @@
+import { useCallback, useState } from "react";
+import Markdown from "react-markdown";
+import { cn } from "./cn.js";
+
+const STORAGE_KEY = "fireworks-thinking-open";
+
+function readPref(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writePref(open: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(open));
+  } catch {
+    /* SSR / restricted env */
+  }
+}
+
+export function ThinkingBlock({
+  thinking,
+  streaming = false,
+  className,
+}: {
+  thinking: string;
+  streaming?: boolean;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(readPref);
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      writePref(next);
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className={cn("flex justify-start", className)}>
+      <div className="rounded-md border border-border/40 bg-accent/20 overflow-hidden">
+        <button
+          type="button"
+          onClick={toggle}
+          className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-muted-foreground/60 hover:bg-accent/30 transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
+            aria-hidden="true"
+          >
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+          {streaming && !open && (
+            <span className="h-2 w-2 shrink-0 rounded-full bg-yellow-500 animate-pulse" />
+          )}
+          <span className="truncate min-w-0">Thinking</span>
+        </button>
+        {open && (
+          <div className="px-2.5 pt-1 pb-2">
+            <ThinkingContent>{thinking}</ThinkingContent>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ThinkingContent({ children }: { children: string }) {
+  return (
+    <div className="text-xs text-muted-foreground/70 italic [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+      <Markdown
+        components={{
+          p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+          ul: ({ children }) => <ul className="mb-2 ml-4 list-disc last:mb-0">{children}</ul>,
+          ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal last:mb-0">{children}</ol>,
+          li: ({ children }) => <li className="mb-0.5">{children}</li>,
+          strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+        }}
+      >
+        {children}
+      </Markdown>
+    </div>
+  );
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -29,6 +29,7 @@ export { getWidget, registerWidget, stripMcpPrefix } from "./registry.js";
 export { StatusDot } from "./StatusDot.js";
 export { type ChatStore, type ChatStoreShape, createChatStore } from "./store.js";
 export { TextMessage } from "./TextMessage.js";
+export { ThinkingBlock } from "./ThinkingBlock.js";
 export { ThinkingIndicator } from "./ThinkingIndicator.js";
 export { ToolApprovalCard } from "./ToolApprovalCard.js";
 export { ToolCallCard } from "./ToolCallCard.js";

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -23,6 +23,7 @@ export interface SessionInit<TCtx> {
   allowedTools?: string[];
   maxTurns?: number;
   permissionMode?: "default" | "acceptEdits" | "plan" | "bypassPermissions";
+  thinking?: { type: "enabled"; budgetTokens: number } | { type: "disabled" };
 }
 
 export interface Session<TCtx> {
@@ -108,6 +109,7 @@ export class SessionManager<TCtx> {
         includePartialMessages: true,
         abortController,
         ...(canUseTool ? { canUseTool } : {}),
+        ...(init.thinking ? { thinking: init.thinking } : {}),
       },
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface ChatMessage {
   id: string;
   role: "user" | "assistant" | "system";
   content: string;
+  thinking?: string;
   toolCalls?: ToolCallInfo[];
 }
 


### PR DESCRIPTION
## Summary
- Surface Claude's extended thinking as collapsible ThinkingBlock components with streaming indicator, markdown rendering, and localStorage persistence
- Server-side thinking event translation with dedup guard to prevent double-emission
- Store buffering with tool-call-aware flushing so thinking blocks survive multi-turn tool use
- Auto-expanding ChatInput textarea

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 43 tests pass (10 new thinking-specific tests across translator + store)
- [x] `npx biome check` clean