### PR TITLE
refactor: extract shared primitives and add test coverage

### DIFF
--- a/src/react/ChatInput.tsx
+++ b/src/react/ChatInput.tsx
@@ -1,5 +1,6 @@
 import { type KeyboardEvent, useCallback, useRef, useState } from "react";
 import { cn } from "./cn.js";
+import { SendIcon } from "./icons.js";
 
 export function ChatInput({
   onSend,
@@ -66,20 +67,7 @@ export function ChatInput({
         disabled={!text.trim() || isDisabled}
         className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-4 w-4"
-          aria-hidden="true"
-        >
-          <path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z" />
-          <path d="m21.854 2.147-10.94 10.939" />
-        </svg>
+        <SendIcon />
       </button>
     </div>
   );

--- a/src/react/CollapsibleCard.tsx
+++ b/src/react/CollapsibleCard.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useState } from "react";
 import type { ToolCallPhase } from "../types.js";
 import { cn } from "./cn.js";
+import { ChevronIcon } from "./icons.js";
 import { StatusDot } from "./StatusDot.js";
 
 export function CollapsibleCard({
@@ -25,19 +26,7 @@ export function CollapsibleCard({
         onClick={() => setOpen(!open)}
         className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-muted-foreground hover:bg-accent transition-colors"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
-          aria-hidden="true"
-        >
-          <path d="m9 18 6-6-6-6" />
-        </svg>
+        <ChevronIcon open={open} />
         {status && <StatusDot status={status} />}
         <span className="truncate min-w-0">{label}</span>
       </button>

--- a/src/react/StatusDot.tsx
+++ b/src/react/StatusDot.tsx
@@ -12,3 +12,14 @@ const phaseClasses: Record<ToolCallPhase, string> = {
 export function StatusDot({ status, className }: { status: ToolCallPhase; className?: string }) {
   return <span className={cn("h-2 w-2 shrink-0 rounded-full", phaseClasses[status], className)} />;
 }
+
+export function PulsingDot({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-block h-2 w-2 shrink-0 rounded-full bg-yellow-500 animate-pulse",
+        className,
+      )}
+    />
+  );
+}

--- a/src/react/TextMessage.tsx
+++ b/src/react/TextMessage.tsx
@@ -1,5 +1,6 @@
 import Markdown from "react-markdown";
 import { cn } from "./cn.js";
+import { markdownComponents } from "./markdown-overrides.js";
 
 export function TextMessage({
   role,
@@ -24,19 +25,7 @@ export function TextMessage({
           <span className="whitespace-pre-wrap">{content}</span>
         ) : (
           <div className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-            <Markdown
-              components={{
-                p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-                ul: ({ children }) => <ul className="mb-2 ml-4 list-disc last:mb-0">{children}</ul>,
-                ol: ({ children }) => (
-                  <ol className="mb-2 ml-4 list-decimal last:mb-0">{children}</ol>
-                ),
-                li: ({ children }) => <li className="mb-0.5">{children}</li>,
-                strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-              }}
-            >
-              {content}
-            </Markdown>
+            <Markdown components={markdownComponents}>{content}</Markdown>
           </div>
         )}
       </div>

--- a/src/react/ThinkingBlock.tsx
+++ b/src/react/ThinkingBlock.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useState } from "react";
 import Markdown from "react-markdown";
 import { cn } from "./cn.js";
+import { ChevronIcon } from "./icons.js";
+import { markdownComponents } from "./markdown-overrides.js";
+import { PulsingDot } from "./StatusDot.js";
 
 const STORAGE_KEY = "fireworks-thinking-open";
 
@@ -47,22 +50,8 @@ export function ThinkingBlock({
           onClick={toggle}
           className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-muted-foreground/60 hover:bg-accent/30 transition-colors"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
-            aria-hidden="true"
-          >
-            <path d="m9 18 6-6-6-6" />
-          </svg>
-          {streaming && !open && (
-            <span className="h-2 w-2 shrink-0 rounded-full bg-yellow-500 animate-pulse" />
-          )}
+          <ChevronIcon open={open} />
+          {streaming && !open && <PulsingDot />}
           <span className="truncate min-w-0">Thinking</span>
         </button>
         {open && (
@@ -78,17 +67,7 @@ export function ThinkingBlock({
 function ThinkingContent({ children }: { children: string }) {
   return (
     <div className="text-xs text-muted-foreground/70 italic [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-      <Markdown
-        components={{
-          p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-          ul: ({ children }) => <ul className="mb-2 ml-4 list-disc last:mb-0">{children}</ul>,
-          ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal last:mb-0">{children}</ol>,
-          li: ({ children }) => <li className="mb-0.5">{children}</li>,
-          strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-        }}
-      >
-        {children}
-      </Markdown>
+      <Markdown components={markdownComponents}>{children}</Markdown>
     </div>
   );
 }

--- a/src/react/ToolApprovalCard.tsx
+++ b/src/react/ToolApprovalCard.tsx
@@ -2,6 +2,7 @@ import type { ToolApprovalRequest } from "../types.js";
 import { ApprovalButtons } from "./ApprovalButtons.js";
 import { cn } from "./cn.js";
 import { getWidget, stripMcpPrefix } from "./registry.js";
+import { PulsingDot } from "./StatusDot.js";
 
 export function ToolApprovalCard({
   request,
@@ -26,7 +27,7 @@ export function ToolApprovalCard({
       )}
     >
       <div className="flex items-center gap-2 text-muted-foreground">
-        <span className="inline-block h-2 w-2 rounded-full bg-yellow-500 animate-pulse" />
+        <PulsingDot />
         <span className="font-medium">{label}</span>
         {request.description && (
           <span className="ml-1 opacity-70">&mdash; {request.description}</span>

--- a/src/react/ToolCallCard.tsx
+++ b/src/react/ToolCallCard.tsx
@@ -4,7 +4,7 @@ import { ApprovalButtons } from "./ApprovalButtons.js";
 import { CollapsibleCard } from "./CollapsibleCard.js";
 import { cn } from "./cn.js";
 import { getWidget, stripMcpPrefix } from "./registry.js";
-import { StatusDot } from "./StatusDot.js";
+import { PulsingDot, StatusDot } from "./StatusDot.js";
 
 export function ToolCallCard({
   toolCall,
@@ -21,9 +21,9 @@ export function ToolCallCard({
   const { respondToPermission, store } = useAgentContext();
   const isNonTerminal = toolCall.status !== "complete" && toolCall.status !== "error";
   const matchingApproval = isNonTerminal
-    ? (pendingPermissions.find(
-        (p) => p.kind === "tool_approval" && p.toolName === toolCall.name,
-      ) as ToolApprovalRequest | undefined)
+    ? (pendingPermissions.find((p) => p.kind === "tool_approval" && p.toolName === toolCall.name) as
+        | ToolApprovalRequest
+        | undefined)
     : undefined;
 
   if (toolCall.status === "complete" && toolCall.result && reg) {
@@ -34,8 +34,9 @@ export function ToolCallCard({
       parsed = toolCall.result;
     }
 
-    const displayLabel =
-      reg.richLabel ? (reg.richLabel(parsed as never, toolCall.input) ?? label) : label;
+    const displayLabel = reg.richLabel
+      ? (reg.richLabel(parsed as never, toolCall.input) ?? label)
+      : label;
 
     const widgetProps: WidgetProps = {
       phase: toolCall.status,
@@ -78,7 +79,7 @@ export function ToolCallCard({
         )}
       >
         <div className="flex items-center gap-2 text-muted-foreground">
-          <span className="inline-block h-2 w-2 rounded-full bg-yellow-500 animate-pulse" />
+          <PulsingDot />
           <span className="font-medium">{label}</span>
           {matchingApproval.description && (
             <span className="ml-1 opacity-70">&mdash; {matchingApproval.description}</span>

--- a/src/react/icons.tsx
+++ b/src/react/icons.tsx
@@ -1,0 +1,38 @@
+import { cn } from "./cn.js";
+
+export function ChevronIcon({ open, className }: { open: boolean; className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn("h-3 w-3 transition-transform", open && "rotate-90", className)}
+      aria-hidden="true"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+export function SendIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn("h-4 w-4", className)}
+      aria-hidden="true"
+    >
+      <path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z" />
+      <path d="m21.854 2.147-10.94 10.939" />
+    </svg>
+  );
+}

--- a/src/react/markdown-overrides.tsx
+++ b/src/react/markdown-overrides.tsx
@@ -1,0 +1,9 @@
+import type { Components } from "react-markdown";
+
+export const markdownComponents: Partial<Components> = {
+  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+  ul: ({ children }) => <ul className="mb-2 ml-4 list-disc last:mb-0">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal last:mb-0">{children}</ol>,
+  li: ({ children }) => <li className="mb-0.5">{children}</li>,
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+};

--- a/src/server/permission-gate.test.ts
+++ b/src/server/permission-gate.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PermissionRequest, PermissionResponse } from "../types.js";
+import { PermissionGate } from "./permission-gate.js";
+
+function toolApproval(id: string): PermissionRequest {
+  return {
+    kind: "tool_approval",
+    requestId: id,
+    toolName: "search",
+    input: { q: "test" },
+  };
+}
+
+function userQuestion(id: string): PermissionRequest {
+  return {
+    kind: "user_question",
+    requestId: id,
+    questions: [
+      { question: "Pick a color", options: [{ label: "Red", description: "Red color" }] },
+    ],
+  };
+}
+
+describe("PermissionGate", () => {
+  it("request() stores pending and notifies listeners", () => {
+    const gate = new PermissionGate();
+    const listener = vi.fn();
+    gate.onRequest(listener);
+
+    const req = toolApproval("r1");
+    gate.request(req);
+
+    expect(listener).toHaveBeenCalledWith(req);
+    expect(gate.getPending()).toEqual([req]);
+  });
+
+  it("respond() resolves the matching promise and returns true", async () => {
+    const gate = new PermissionGate();
+    const req = toolApproval("r1");
+    const promise = gate.request(req);
+
+    const response: PermissionResponse = {
+      kind: "tool_approval",
+      requestId: "r1",
+      behavior: "allow",
+    };
+    const found = gate.respond(response);
+
+    expect(found).toBe(true);
+    expect(gate.getPending()).toHaveLength(0);
+    await expect(promise).resolves.toEqual(response);
+  });
+
+  it("respond() returns false for unknown requestId", () => {
+    const gate = new PermissionGate();
+    const result = gate.respond({
+      kind: "tool_approval",
+      requestId: "unknown",
+      behavior: "deny",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("onRequest() returns an unsubscribe function", () => {
+    const gate = new PermissionGate();
+    const listener = vi.fn();
+    const unsub = gate.onRequest(listener);
+
+    unsub();
+    gate.request(toolApproval("r1"));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("getPending() returns snapshot of current requests", () => {
+    const gate = new PermissionGate();
+    gate.request(toolApproval("r1"));
+    gate.request(userQuestion("r2"));
+
+    const pending = gate.getPending();
+    expect(pending).toHaveLength(2);
+    expect(pending[0].requestId).toBe("r1");
+    expect(pending[1].requestId).toBe("r2");
+  });
+
+  it("cancelAll() resolves tool approvals with deny", async () => {
+    const gate = new PermissionGate();
+    const promise = gate.request(toolApproval("r1"));
+
+    gate.cancelAll("session ended");
+
+    const result = await promise;
+    expect(result).toEqual({
+      kind: "tool_approval",
+      requestId: "r1",
+      behavior: "deny",
+      message: "session ended",
+    });
+    expect(gate.getPending()).toHaveLength(0);
+  });
+
+  it("cancelAll() resolves user questions with empty answers", async () => {
+    const gate = new PermissionGate();
+    const promise = gate.request(userQuestion("r1"));
+
+    gate.cancelAll("session ended");
+
+    const result = await promise;
+    expect(result).toEqual({
+      kind: "user_question",
+      requestId: "r1",
+      answers: {},
+    });
+    expect(gate.getPending()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `ChevronIcon`, `SendIcon` into shared `icons.tsx`; `PulsingDot` into `StatusDot.tsx`; `markdownComponents` into `markdown-overrides.tsx`
- Add `PermissionGate` test suite (7 tests) and 4 new store edge-case tests

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (54 tests)
- [x] `npx biome check src/` clean on touched files