### PR TITLE
ci: add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test
+      - run: pnpm publish --access public --no-git-checks --provenance

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/quantumleeps/fireworks-ai/issues"
   },
   "keywords": ["claude", "agent-sdk", "react", "hono", "sse", "chat-ui", "anthropic"],
+  "packageManager": "pnpm@10.22.0",
   "sideEffects": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Add `release.yml` workflow triggered on `v*` tag push — builds, tests, publishes via OIDC trusted publishing
- Add `packageManager` field to `package.json` for `pnpm/action-setup@v4`

## Test plan
- [x] Trusted publisher configured on npmjs.com
- [x] Next version tag push triggers workflow and publishes successfully