### PR TITLE
fix(ci): use Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
       - run: pnpm build


### PR DESCRIPTION
## Summary
- OIDC trusted publishing requires npm 11.5.1+, which ships with Node 24 (Node 22 ships with npm 10)
- Changes `node-version: 22` → `node-version: 24` in release workflow

## Test plan
- [x] Re-run failed v0.4.2 workflow after merge