### PR TITLE
fix(theme): use Tailwind built-in colors for status indicators

### DIFF
--- a/src/react/StatusDot.tsx
+++ b/src/react/StatusDot.tsx
@@ -3,9 +3,9 @@ import { cn } from "./cn.js";
 
 const phaseClasses: Record<ToolCallPhase, string> = {
   pending: "bg-muted-foreground/40",
-  streaming_input: "bg-warning animate-pulse",
-  running: "bg-warning animate-pulse",
-  complete: "bg-success",
+  streaming_input: "bg-amber-500 animate-pulse",
+  running: "bg-amber-500 animate-pulse",
+  complete: "bg-emerald-500",
   error: "bg-destructive",
 };
 
@@ -17,7 +17,7 @@ export function PulsingDot({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        "inline-block h-2 w-2 shrink-0 rounded-full bg-warning animate-pulse",
+        "inline-block h-2 w-2 shrink-0 rounded-full bg-amber-500 animate-pulse",
         className,
       )}
     />

--- a/src/react/ToolApprovalCard.tsx
+++ b/src/react/ToolApprovalCard.tsx
@@ -22,7 +22,7 @@ export function ToolApprovalCard({
   return (
     <div
       className={cn(
-        "rounded-md border border-warning/40 bg-warning/5 px-3 py-2.5 text-xs",
+        "rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2.5 text-xs",
         className,
       )}
     >

--- a/src/react/ToolCallCard.tsx
+++ b/src/react/ToolCallCard.tsx
@@ -74,7 +74,7 @@ export function ToolCallCard({
     return (
       <div
         className={cn(
-          "rounded-md border border-warning/40 bg-warning/5 px-3 py-2.5 text-xs",
+          "rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2.5 text-xs",
           className,
         )}
       >

--- a/src/react/UserQuestionCard.tsx
+++ b/src/react/UserQuestionCard.tsx
@@ -94,7 +94,7 @@ export function UserQuestionCard({
       ref={wrapperRef}
       tabIndex={-1}
       className={cn(
-        "rounded-md border border-info/40 bg-info/5 px-3 py-2.5 text-xs focus:outline-none",
+        "rounded-md border border-blue-500/40 bg-blue-500/5 px-3 py-2.5 text-xs focus:outline-none",
         className,
       )}
     >
@@ -129,7 +129,7 @@ export function UserQuestionCard({
                       className={cn(
                         "flex items-start gap-2 rounded border px-2 py-1.5 text-left transition-colors",
                         selected
-                          ? "border-info bg-info/15 text-foreground ring-1 ring-info/30"
+                          ? "border-blue-500 bg-blue-500/15 text-foreground ring-1 ring-blue-500/30"
                           : "border-border text-muted-foreground hover:bg-accent",
                       )}
                     >
@@ -161,7 +161,7 @@ export function UserQuestionCard({
                         className={cn(
                           "flex w-full items-start gap-2 rounded border px-2 py-1.5 text-left transition-colors",
                           isOther
-                            ? "border-info bg-info/15 text-foreground ring-1 ring-info/30"
+                            ? "border-blue-500 bg-blue-500/15 text-foreground ring-1 ring-blue-500/30"
                             : "border-border text-muted-foreground hover:bg-accent",
                         )}
                       >
@@ -179,7 +179,7 @@ export function UserQuestionCard({
                             otherInputRefs.current[q.question] = el;
                           }}
                           type="text"
-                          className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-foreground focus:outline-none focus:ring-1 focus:ring-info/50"
+                          className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-foreground focus:outline-none focus:ring-1 focus:ring-blue-500/50"
                           placeholder="Type your answer…"
                           value={otherText[q.question] ?? ""}
                           onChange={(e) =>
@@ -202,7 +202,7 @@ export function UserQuestionCard({
             {!hasOptions && (
               <input
                 type="text"
-                className="mt-1.5 w-full rounded border border-border bg-background px-2 py-1 text-foreground focus:outline-none focus:ring-1 focus:ring-info/50"
+                className="mt-1.5 w-full rounded border border-border bg-background px-2 py-1 text-foreground focus:outline-none focus:ring-1 focus:ring-blue-500/50"
                 placeholder="Type your answer…"
                 value={answers[q.question] ?? ""}
                 onChange={(e) => setAnswers((prev) => ({ ...prev, [q.question]: e.target.value }))}

--- a/src/theme.css
+++ b/src/theme.css
@@ -4,11 +4,11 @@
  * Provides the CSS variable bridge (via @theme inline) and a neutral color
  * palette so fireworks-ai components render correctly out of the box.
  *
- * If your app already uses shadcn/ui, you DON'T need this file — your existing
- * shadcn/tailwind.css and color variables are already compatible. Only import
- * this if you're NOT using shadcn.
+ * If your app already uses shadcn/ui you don't need this file — fireworks-ai
+ * components use only standard shadcn variables plus Tailwind's built-in
+ * color palette (amber, emerald, blue) for status indicators.
  *
- * Usage:
+ * Usage (non-shadcn apps):
  *   @import "fireworks-ai/theme.css";
  */
 


### PR DESCRIPTION
## Summary
- Replace custom `--warning`/`--success`/`--info` CSS variables with Tailwind's built-in `amber-500`/`emerald-500`/`blue-500`
- shadcn's default palette doesn't include these custom variables, so status dots and card tints were invisible for shadcn consumers
- `theme.css` comment updated to reflect shadcn apps no longer need it

## Test plan
- [x] `pnpm build` passes
- [x] Verified in Maven (shadcn app) via `pnpm link` — status dots render correctly