### PR TITLE
fix(react): point theme.css @source at dist/ instead of src/

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,10 +251,10 @@ Your existing theme variables are already compatible. Add one line to your main 
 
 ```css
 @import "tailwindcss";
-@source "../node_modules/@neeter/react/src";
+@source "../node_modules/@neeter/react/dist";
 ```
 
-The `@source` path is relative to your CSS file — adjust if your stylesheet lives in a nested directory (e.g. `../../node_modules/@neeter/react/src`).
+The `@source` path is relative to your CSS file — adjust if your stylesheet lives in a nested directory (e.g. `../../node_modules/@neeter/react/dist`).
 
 ### Without shadcn/ui
 

--- a/packages/react/src/theme.css
+++ b/packages/react/src/theme.css
@@ -15,7 +15,7 @@
 /* -- Source scanning ------------------------------------------------------- */
 /* Tells Tailwind to scan neeter's component source for utility classes. */
 
-@source ".";
+@source "../dist";
 
 /* -- Tailwind v4 variable bridge ------------------------------------------ */
 /* Maps CSS custom properties to Tailwind utility classes.                     */


### PR DESCRIPTION
Closes #21

## Summary
- **`@source` pointed at wrong directory** — `theme.css` lives in `src/` so `@source "."` scanned `src/` (only `theme.css` itself), missing all compiled components in `dist/`. Changed to `@source "../dist"`
- **README shadcn path updated** — the manual `@source` instruction for shadcn users also pointed at `src` instead of `dist`

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 69 tests pass
- [x] Verified `@source "../dist"` resolves correctly from `src/theme.css` to `dist/`