### PR TITLE
docs: add npm-facing READMEs for each subpackage

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,92 @@
+# @neeter/react
+
+React components and hooks for building chat UIs on top of the [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk). Connects to an `@neeter/server` backend over SSE with a Zustand store, drop-in components, and a widget system for tool call rendering.
+
+Part of the [neeter](https://github.com/quantumleeps/neeter) toolkit.
+
+## Install
+
+```bash
+pnpm add @neeter/react
+```
+
+Peer dependencies:
+
+```json
+{
+  "react": ">=18.0.0",
+  "react-markdown": ">=10.0.0",
+  "zustand": ">=5.0.0",
+  "immer": ">=10.0.0"
+}
+```
+
+Components use [Tailwind CSS v4](https://tailwindcss.com/) utility classes.
+
+## Quick start
+
+```tsx
+import { AgentProvider, MessageList, ChatInput, useAgentContext } from "@neeter/react";
+
+function App() {
+  return (
+    <AgentProvider>
+      <Chat />
+    </AgentProvider>
+  );
+}
+
+function Chat() {
+  const { sendMessage } = useAgentContext();
+
+  return (
+    <div className="flex h-screen flex-col">
+      <MessageList className="flex-1" />
+      <ChatInput onSend={sendMessage} />
+    </div>
+  );
+}
+```
+
+## Styling
+
+Components use [shadcn/ui](https://ui.shadcn.com)-compatible CSS variable names. If you already have a shadcn theme, add one line:
+
+```css
+@import "tailwindcss";
+@source "../node_modules/@neeter/react/dist";
+```
+
+Without shadcn, import the bundled theme:
+
+```css
+@import "tailwindcss";
+@import "@neeter/react/theme.css";
+```
+
+## Key features
+
+- **11 built-in widgets** — Diff views for edits, code blocks for reads, expandable pills for web searches, and more. Auto-registered on import.
+- **Custom widgets** — Register your own components for MCP tools or app-specific rendering with `registerWidget()`.
+- **Tool call lifecycle** — Each tool moves through `pending` → `streaming_input` → `running` → `complete` with streaming JSON input.
+- **Permissions UI** — `ToolApprovalCard` and `UserQuestionCard` for browser-side tool approval.
+- **Extended thinking** — Collapsible thinking blocks with streaming text.
+- **Custom events** — Handle app-specific events from `onToolResult` via `AgentProvider`'s `onCustomEvent` prop.
+- **Abort** — Stop the agent mid-turn with `stopSession()` from `useAgentContext()`.
+
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| [basic-chat](https://github.com/quantumleeps/neeter/tree/main/examples/basic-chat) | Minimal component setup |
+| [live-preview](https://github.com/quantumleeps/neeter/tree/main/examples/live-preview) | Custom events, widgets, split-pane preview |
+
+## Documentation
+
+- [Full API reference](https://github.com/quantumleeps/neeter#readme)
+- [Built-in widgets](https://github.com/quantumleeps/neeter/blob/main/docs/built-in-widgets.md)
+- [Custom widgets](https://github.com/quantumleeps/neeter/blob/main/docs/custom-widgets.md)
+
+## License
+
+MIT

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,7 +20,8 @@
   },
   "files": [
     "dist",
-    "src/theme.css"
+    "src/theme.css",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json"

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,81 @@
+# @neeter/server
+
+A Hono server toolkit that puts a browser UI on the [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk). Manages multi-turn sessions, translates SDK messages into named SSE events, and handles tool-approval permissions — so your React client gets a clean event stream out of the box.
+
+Part of the [neeter](https://github.com/quantumleeps/neeter) toolkit.
+
+## Install
+
+```bash
+pnpm add @neeter/server
+```
+
+Peer dependencies:
+
+```json
+{
+  "@anthropic-ai/claude-agent-sdk": ">=0.2.0",
+  "hono": ">=4.0.0"
+}
+```
+
+## Quick start
+
+```typescript
+import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import {
+  createAgentRouter,
+  SessionManager,
+  MessageTranslator,
+} from "@neeter/server";
+
+const sessions = new SessionManager(() => ({
+  context: {},
+  model: "claude-sonnet-4-5-20250929",
+  systemPrompt: "You are a helpful assistant.",
+  maxTurns: 50,
+}));
+
+const translator = new MessageTranslator();
+
+const app = new Hono();
+app.route("/", createAgentRouter({ sessions, translator }));
+
+serve({ fetch: app.fetch, port: 3000 });
+```
+
+This gives you five endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/sessions` | Create a session |
+| `POST` | `/api/sessions/:id/messages` | Send a message |
+| `GET` | `/api/sessions/:id/events` | SSE event stream |
+| `POST` | `/api/sessions/:id/permissions` | Respond to a permission request |
+| `POST` | `/api/sessions/:id/abort` | Abort the current turn |
+
+## Key features
+
+- **Multi-turn sessions** — `SessionManager` + `PushChannel` let users send messages at any time, even while the agent is running.
+- **Named SSE events** — `MessageTranslator` reshapes the SDK's flat message stream into `text_delta`, `tool_start`, `tool_call`, `tool_result`, and more.
+- **Tool result hooks** — `onToolResult` lets you inspect what the agent did and emit structured custom events.
+- **Permission modes** — `bypassPermissions`, `default`, `acceptEdits`, or `plan` — with browser-side approval via `PermissionGate`.
+- **Extended thinking** — Pass `thinking: { type: "enabled", budgetTokens: N }` to stream chain-of-thought reasoning.
+- **Abort** — Cancel the current agent turn mid-stream.
+- **Sandbox hooks** — `createSandboxHook` restricts file operations to a directory.
+
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| [basic-chat](https://github.com/quantumleeps/neeter/tree/main/examples/basic-chat) | Minimal server + client setup |
+| [live-preview](https://github.com/quantumleeps/neeter/tree/main/examples/live-preview) | Per-session sandboxes, custom events, abort |
+
+## Documentation
+
+See the [neeter README](https://github.com/quantumleeps/neeter#readme) for full API reference, session context examples, and permission configuration.
+
+## License
+
+MIT

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json"

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,25 @@
+# @neeter/types
+
+Shared TypeScript types for the [neeter](https://github.com/quantumleeps/neeter) toolkit.
+
+## Install
+
+```bash
+pnpm add @neeter/types
+```
+
+> Most users don't need this package directly — all types are re-exported from `@neeter/server` and `@neeter/react`.
+
+## What's inside
+
+- **SSE protocol** — `SSEEvent`, `CustomEvent<T>`
+- **Chat messages** — `ChatMessage`, `ToolCallInfo`, `ToolCallPhase`
+- **Permissions** — `PermissionRequest`, `PermissionResponse`, `ToolApprovalRequest`, `ToolApprovalResponse`, `UserQuestion`, `UserQuestionRequest`, `UserQuestionResponse`
+
+## Documentation
+
+See the [neeter README](https://github.com/quantumleeps/neeter#readme) for full API reference and usage guides.
+
+## License
+
+MIT

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,7 +17,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json"


### PR DESCRIPTION
## Summary
- **Package READMEs** — `@neeter/types`, `@neeter/server`, and `@neeter/react` had no READMEs, so npmjs.com showed no documentation. Each now has a concise README with install, peer deps, quick start, key features, example links, and pointers back to the monorepo.
- **`files` array updates** — Added `"README.md"` to each `package.json` so the READMEs ship in the npm tarball.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 82 tests pass
- [x] Spot-checked markdown rendering