### PR TITLE
docs(live-preview): add demo video to README

### DIFF
--- a/examples/live-preview/README.md
+++ b/examples/live-preview/README.md
@@ -5,6 +5,8 @@ a React app in real time on the right. Each session gets an isolated
 sandbox with Tailwind CSS and a curated set of libraries — the agent
 writes pure JSX and the preview updates on every edit.
 
+https://github.com/user-attachments/assets/5f442559-a69c-44ab-b739-9d18ecac2add
+
 > **Warning — experimental.** This example gives an AI agent access to a
 > local filesystem directory. It is designed for experimentation only and
 > is **not suitable for production use** without extensive hardening (see


### PR DESCRIPTION
## Summary
- **Demo video** — add a hosted video link to the live-preview example README so visitors can see the split-pane coding assistant in action before setting it up

## Test plan
- [x] Video link renders correctly on GitHub