### PR TITLE
feat(basic-chat): wire up stop button

### DIFF
--- a/examples/basic-chat/src/App.tsx
+++ b/examples/basic-chat/src/App.tsx
@@ -1,7 +1,14 @@
-import { AgentProvider, ChatInput, MessageList, useAgentContext } from "@neeter/react";
+import {
+  AgentProvider,
+  ChatInput,
+  MessageList,
+  useAgentContext,
+  useChatStore,
+} from "@neeter/react";
 
 function Chat() {
-  const { sendMessage } = useAgentContext();
+  const { sendMessage, stopSession } = useAgentContext();
+  const isStreaming = useChatStore((s) => s.isStreaming);
 
   return (
     <div className="flex h-screen flex-col bg-background text-foreground">
@@ -10,7 +17,7 @@ function Chat() {
       </header>
       <MessageList className="flex-1" />
       <div className="border-t">
-        <ChatInput onSend={sendMessage} />
+        <ChatInput onSend={sendMessage} onStop={stopSession} isStreaming={isStreaming} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Wires `onStop` and `isStreaming` props into `ChatInput` in the basic-chat example
- The stop button, abort endpoint, and hook were already built — this just connects them in the example app