### PR TITLE
feat(server): add extraArgs and env passthrough to SessionInit

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,7 +11,7 @@ For usage examples, see the [Server Guide](server.md) and [Client Guide](client.
 | `SessionManager<TCtx>` | Manages agent sessions — create, resume, list history, optional persistence |
 | `SessionManagerOptions` | Constructor options — `idleTimeoutMs`, `store` |
 | `Session<TCtx>` | A single session — `id`, `sdkSessionId`, `context`, `pushMessage()`, `permissionGate`, `abort()` |
-| `SessionInit<TCtx>` | Factory return type — `model`, `systemPrompt`, `permissionMode`, `mcpServers`, etc. |
+| `SessionInit<TCtx>` | Factory return type — `model`, `systemPrompt`, `permissionMode`, `mcpServers`, `extraArgs`, `env`, etc. |
 | `ResumeOptions` | Options for `SessionManager.resume()` — `sdkSessionId`, `forkSession` |
 | `sessionMeta(session)` | Extract a `SessionHistoryEntry` from a `Session` |
 | `createJsonSessionStore(dataDir)` | File-based `SessionStore` using append-only JSONL + JSON metadata |

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -86,6 +86,40 @@ describe("SessionManager.resume", () => {
   });
 });
 
+describe("SessionInit passthrough", () => {
+  it("forwards extraArgs to query options", () => {
+    const mgr = new SessionManager<{ n: number }>(() => ({
+      context: { n: 1 },
+      model: "test",
+      systemPrompt: "test",
+      extraArgs: { "replay-user-messages": null },
+    }));
+    mgr.create();
+
+    expect(lastQueryOptions?.extraArgs).toEqual({ "replay-user-messages": null });
+  });
+
+  it("forwards env to query options", () => {
+    const mgr = new SessionManager<{ n: number }>(() => ({
+      context: { n: 1 },
+      model: "test",
+      systemPrompt: "test",
+      env: { CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: "1" },
+    }));
+    mgr.create();
+
+    expect(lastQueryOptions?.env).toEqual({ CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: "1" });
+  });
+
+  it("omits extraArgs and env when not provided", () => {
+    const mgr = createManager();
+    mgr.create();
+
+    expect(lastQueryOptions).not.toHaveProperty("extraArgs");
+    expect(lastQueryOptions).not.toHaveProperty("env");
+  });
+});
+
 describe("SessionManager.listHistory", () => {
   it("returns empty when no sessions exist", async () => {
     const mgr = createManager();

--- a/packages/server/src/session.ts
+++ b/packages/server/src/session.ts
@@ -42,6 +42,10 @@ export interface SessionInit<TCtx> {
   thinking?: { type: "enabled"; budgetTokens: number } | { type: "disabled" };
   /** SDK lifecycle hooks (e.g. `PreToolUse` for sandbox enforcement via `createSandboxHook`). */
   hooks?: Partial<Record<HookEvent, HookCallbackMatcher[]>>;
+  /** Extra CLI flags forwarded to the Claude Code subprocess. */
+  extraArgs?: Record<string, string | null>;
+  /** Environment variables forwarded to the Claude Code subprocess. */
+  env?: Record<string, string | undefined>;
 }
 
 export interface ResumeOptions {
@@ -242,6 +246,8 @@ export class SessionManager<TCtx> {
         ...(init.cwd ? { cwd: init.cwd } : {}),
         ...(init.disallowedTools ? { disallowedTools: init.disallowedTools } : {}),
         ...(init.hooks ? { hooks: init.hooks } : {}),
+        ...(init.extraArgs ? { extraArgs: init.extraArgs } : {}),
+        ...(init.env ? { env: init.env } : {}),
         ...extraQueryOptions,
       },
     });


### PR DESCRIPTION
## Summary

- Adds `extraArgs` and `env` optional fields to `SessionInit`
- Forwards both to the SDK's `query()` options
- Unit tests verify passthrough and omission behavior
- E2E verified: `env` values reach the Claude Code subprocess (confirmed via Bash tool echoing a custom env var)

Unblocks #46 (file checkpointing) and #54 (sandbox-isolated forking).

Closes #47