### PR TITLE
ci: consolidate dependabot to root directory for pnpm monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,6 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
-  - package-ecosystem: npm
-    directory: /packages/types
-    schedule:
-      interval: weekly
-  - package-ecosystem: npm
-    directory: /packages/server
-    schedule:
-      interval: weekly
-  - package-ecosystem: npm
-    directory: /packages/react
-    schedule:
-      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary
- Remove per-directory dependabot entries for `/packages/types`, `/packages/server`, and `/packages/react`
- Keep only the root `/` entry since pnpm resolves all workspace packages from a single root lockfile
- Prevents duplicate PRs (e.g. #17/#26 for hono, #18/#20 for tailwind-merge)

## Test plan
- [x] `pnpm check && pnpm build && pnpm test` passes
- [ ] Verify next weekly dependabot run creates non-duplicate PRs