### PR TITLE
fix(server): align createSandboxHook with documented SDK hook output format

### DIFF
--- a/packages/server/src/hooks.test.ts
+++ b/packages/server/src/hooks.test.ts
@@ -41,8 +41,11 @@ describe("createSandboxHook", () => {
       signal: AbortSignal.timeout(5000),
     });
     expect(result).toEqual({
-      decision: "block",
-      reason: "Access outside sandbox directory is not allowed",
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Access outside sandbox directory is not allowed",
+      },
     });
   });
 
@@ -53,8 +56,11 @@ describe("createSandboxHook", () => {
       { signal: AbortSignal.timeout(5000) },
     );
     expect(result).toEqual({
-      decision: "block",
-      reason: "Access outside sandbox directory is not allowed",
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Access outside sandbox directory is not allowed",
+      },
     });
   });
 
@@ -65,8 +71,11 @@ describe("createSandboxHook", () => {
       { signal: AbortSignal.timeout(5000) },
     );
     expect(result).toEqual({
-      decision: "block",
-      reason: "Access outside sandbox directory is not allowed",
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Access outside sandbox directory is not allowed",
+      },
     });
   });
 
@@ -84,8 +93,11 @@ describe("createSandboxHook", () => {
       { signal: AbortSignal.timeout(5000) },
     );
     expect(result).toEqual({
-      decision: "block",
-      reason: "Access outside sandbox directory is not allowed",
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Access outside sandbox directory is not allowed",
+      },
     });
   });
 
@@ -114,8 +126,11 @@ describe("createSandboxHook", () => {
     const resolved = resolve("index.html");
     if (!resolved.startsWith(sandboxDir)) {
       expect(result).toEqual({
-        decision: "block",
-        reason: "Access outside sandbox directory is not allowed",
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: "Access outside sandbox directory is not allowed",
+        },
       });
     }
   });
@@ -125,8 +140,11 @@ describe("createSandboxHook", () => {
       signal: AbortSignal.timeout(5000),
     });
     expect(result).toEqual({
-      decision: "block",
-      reason: expect.stringContaining("Bash is blocked in sandbox mode"),
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.stringContaining("Bash is blocked in sandbox mode"),
+      },
     });
   });
 

--- a/packages/server/src/hooks.ts
+++ b/packages/server/src/hooks.ts
@@ -1,7 +1,7 @@
 import type {
   HookCallbackMatcher,
-  HookInput,
   HookJSONOutput,
+  PreToolUseHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 
 export interface SandboxHookOptions {
@@ -48,26 +48,35 @@ export function createSandboxHook(
   return [
     {
       hooks: [
-        async (input: HookInput): Promise<HookJSONOutput> => {
+        async (input): Promise<HookJSONOutput> => {
           if (input.hook_event_name !== "PreToolUse") return {};
 
-          const toolName = (input as Record<string, unknown>).tool_name as string | undefined;
-          if (toolName === "Bash" && !allowBash) {
+          const preInput = input as PreToolUseHookInput;
+          if (preInput.tool_name === "Bash" && !allowBash) {
             return {
-              decision: "block",
-              reason:
-                "Bash is blocked in sandbox mode — shell commands can reference arbitrary paths. " +
-                "Use allowBash with OS-level isolation (containers, sandbox-runtime) for Bash access. " +
-                "See https://platform.claude.com/docs/en/agent-sdk/secure-deployment",
+              hookSpecificOutput: {
+                hookEventName: input.hook_event_name,
+                permissionDecision: "deny",
+                permissionDecisionReason:
+                  "Bash is blocked in sandbox mode — shell commands can reference arbitrary paths. " +
+                  "Use allowBash with OS-level isolation (containers, sandbox-runtime) for Bash access. " +
+                  "See https://platform.claude.com/docs/en/agent-sdk/secure-deployment",
+              },
             };
           }
 
-          const toolInput = input.tool_input as Record<string, unknown>;
+          const toolInput = preInput.tool_input as Record<string, unknown>;
           const filePath = (toolInput.file_path ?? toolInput.path) as string | undefined;
           if (!filePath) return {};
           const resolved = resolvePath(filePath);
           if (resolved !== normalizedDir && !resolved.startsWith(`${normalizedDir}/`)) {
-            return { decision: "block", reason: "Access outside sandbox directory is not allowed" };
+            return {
+              hookSpecificOutput: {
+                hookEventName: input.hook_event_name,
+                permissionDecision: "deny",
+                permissionDecisionReason: "Access outside sandbox directory is not allowed",
+              },
+            };
           }
           return {};
         },


### PR DESCRIPTION
## Summary

- Replace undocumented shorthand (`decision`/`reason`) in `createSandboxHook` with the SDK's documented `hookSpecificOutput` format (`permissionDecision`/`permissionDecisionReason`)
- Clean up `Record<string, unknown>` cast — use `PreToolUseHookInput` from the SDK which already has `tool_name`
- Update all test assertions to match

Closes #34