### PR TITLE
fix(server,react): surface is_error from tool results so denied tools show error state

### DIFF
--- a/packages/react/src/replay.test.ts
+++ b/packages/react/src/replay.test.ts
@@ -99,6 +99,35 @@ describe("replayEvents", () => {
     expect(messages[1]).toMatchObject({ role: "system", content: "Session ended: error" });
   });
 
+  it("replays an errored tool result", () => {
+    const store = createChatStore();
+    replayEvents(store, [
+      { event: "user_message", data: JSON.stringify({ text: "Write to /etc" }) },
+      { event: "tool_start", data: JSON.stringify({ id: "tu-e", name: "Write" }) },
+      {
+        event: "tool_call",
+        data: JSON.stringify({ id: "tu-e", name: "Write", input: { file_path: "/etc/passwd" } }),
+      },
+      {
+        event: "tool_result",
+        data: JSON.stringify({
+          toolUseId: "tu-e",
+          result: "Access outside sandbox directory is not allowed",
+          isError: true,
+        }),
+      },
+      { event: "turn_complete", data: JSON.stringify({ cost: 0.01, numTurns: 1 }) },
+    ]);
+
+    const { messages } = store.getState();
+    expect(messages[1].toolCalls?.[0]).toMatchObject({
+      id: "tu-e",
+      name: "Write",
+      status: "error",
+      error: "Access outside sandbox directory is not allowed",
+    });
+  });
+
   it("handles empty events array", () => {
     const store = createChatStore();
     replayEvents(store, []);

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -288,7 +288,11 @@ export function replayEvents(store: ChatStore, events: SSEEvent[]): void {
         s.finalizeToolCall(data.id, data.name, data.input);
         break;
       case "tool_result":
-        s.completeToolCall(data.toolUseId, data.result);
+        if (data.isError) {
+          s.errorToolCall(data.toolUseId, data.result);
+        } else {
+          s.completeToolCall(data.toolUseId, data.result);
+        }
         break;
       case "turn_complete":
         s.flushStreamingThinking();

--- a/packages/react/src/use-agent.ts
+++ b/packages/react/src/use-agent.ts
@@ -121,8 +121,12 @@ export function useAgent(store: ChatStore, config?: UseAgentConfig): UseAgentRet
     });
 
     es.addEventListener("tool_result", (e) => {
-      const { toolUseId, result } = JSON.parse(e.data);
-      store.getState().completeToolCall(toolUseId, result);
+      const { toolUseId, result, isError } = JSON.parse(e.data);
+      if (isError) {
+        store.getState().errorToolCall(toolUseId, result);
+      } else {
+        store.getState().completeToolCall(toolUseId, result);
+      }
       if (store.getState().isStreaming) {
         store.getState().setThinking(true);
       }

--- a/packages/server/src/translator.test.ts
+++ b/packages/server/src/translator.test.ts
@@ -125,7 +125,48 @@ describe("MessageTranslator", () => {
       session,
     );
     expect(events).toEqual([
-      { event: "tool_result", data: JSON.stringify({ toolUseId: "t-2", result: "42" }) },
+      {
+        event: "tool_result",
+        data: JSON.stringify({ toolUseId: "t-2", result: "42", isError: false }),
+      },
+    ]);
+  });
+
+  it("emits tool_result with isError true when is_error is set", () => {
+    const t = new MessageTranslator();
+    t.translate(
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "t-err", name: "Write", input: {} }] },
+      },
+      session,
+    );
+    const events = t.translate(
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t-err",
+              is_error: true,
+              content: "Access outside sandbox directory is not allowed",
+            },
+          ],
+        },
+      },
+      session,
+    );
+    expect(events).toEqual([
+      {
+        event: "tool_result",
+        data: JSON.stringify({
+          toolUseId: "t-err",
+          result: "Access outside sandbox directory is not allowed",
+          isError: true,
+        }),
+      },
     ]);
   });
 
@@ -154,7 +195,7 @@ describe("MessageTranslator", () => {
     expect(events).toHaveLength(2);
     expect(events[0]).toEqual({
       event: "tool_result",
-      data: JSON.stringify({ toolUseId: "t-3", result: "ok" }),
+      data: JSON.stringify({ toolUseId: "t-3", result: "ok", isError: false }),
     });
     expect(events[1]).toEqual({
       event: "custom",

--- a/packages/server/src/translator.ts
+++ b/packages/server/src/translator.ts
@@ -151,11 +151,12 @@ export class MessageTranslator<TCtx> {
           for (const block of msg.content) {
             if (block.type === "tool_result") {
               const text = extractToolResultText(block);
+              const isError = block.is_error === true;
               const toolName = this.toolNames.get(block.tool_use_id as string);
 
               events.push({
                 event: "tool_result",
-                data: JSON.stringify({ toolUseId: block.tool_use_id, result: text }),
+                data: JSON.stringify({ toolUseId: block.tool_use_id, result: text, isError }),
               });
 
               if (this.config.onToolResult && toolName) {


### PR DESCRIPTION
## Summary

- Extract `is_error` from SDK tool_result blocks in the translator and pass it through as `isError` in the SSE event
- Route to `errorToolCall()` instead of `completeToolCall()` when `isError` is true, in both live SSE and replay paths
- Denied tool calls now show a red error dot instead of a green success dot

Closes #69