### PR TITLE
feat(server): surface MCP server connection status from system init

### DIFF
--- a/packages/react/src/replay.test.ts
+++ b/packages/react/src/replay.test.ts
@@ -8,15 +8,21 @@ describe("replayEvents", () => {
       { event: "user_message", data: JSON.stringify({ text: "Hello" }) },
       {
         event: "session_init",
-        data: JSON.stringify({ sdkSessionId: "sdk-1", model: "test", tools: [] }),
+        data: JSON.stringify({
+          sdkSessionId: "sdk-1",
+          model: "test",
+          tools: [],
+          mcpServers: [{ name: "github", status: "connected" }],
+        }),
       },
       { event: "text_delta", data: JSON.stringify({ text: "Hi " }) },
       { event: "text_delta", data: JSON.stringify({ text: "there!" }) },
       { event: "turn_complete", data: JSON.stringify({ cost: 0.01, numTurns: 1 }) },
     ]);
 
-    const { messages, sdkSessionId, totalCost, totalTurns } = store.getState();
+    const { messages, sdkSessionId, mcpServers, totalCost, totalTurns } = store.getState();
     expect(sdkSessionId).toBe("sdk-1");
+    expect(mcpServers).toEqual([{ name: "github", status: "connected" }]);
     expect(messages).toHaveLength(2);
     expect(messages[0]).toMatchObject({ role: "user", content: "Hello" });
     expect(messages[1]).toMatchObject({ role: "assistant", content: "Hi there!" });

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -1,4 +1,10 @@
-import type { ChatMessage, PermissionRequest, SSEEvent, ToolCallInfo } from "@neeter/types";
+import type {
+  ChatMessage,
+  McpServerStatus,
+  PermissionRequest,
+  SSEEvent,
+  ToolCallInfo,
+} from "@neeter/types";
 import { immer } from "zustand/middleware/immer";
 import { createStore, type StoreApi } from "zustand/vanilla";
 
@@ -11,6 +17,7 @@ interface ChatStoreState {
   streamingText: string;
   streamingThinking: string;
   pendingPermissions: PermissionRequest[];
+  mcpServers: McpServerStatus[];
   totalCost: number;
   totalTurns: number;
 }
@@ -33,6 +40,7 @@ interface ChatStoreActions {
   setThinking: (v: boolean) => void;
   addPermissionRequest: (request: PermissionRequest) => void;
   removePermissionRequest: (requestId: string) => void;
+  setMcpServers: (servers: McpServerStatus[]) => void;
   addCost: (cost: number, turns: number) => void;
   cancelInflightToolCalls: () => void;
   reset: () => void;
@@ -69,6 +77,7 @@ export function createChatStore(): ChatStore {
       streamingText: "",
       streamingThinking: "",
       pendingPermissions: [],
+      mcpServers: [],
       totalCost: 0,
       totalTurns: 0,
 
@@ -214,6 +223,11 @@ export function createChatStore(): ChatStore {
           s.pendingPermissions = s.pendingPermissions.filter((p) => p.requestId !== requestId);
         }),
 
+      setMcpServers: (servers) =>
+        set((s) => {
+          s.mcpServers = servers;
+        }),
+
       addCost: (cost, turns) =>
         set((s) => {
           s.totalCost += cost;
@@ -248,6 +262,7 @@ export function createChatStore(): ChatStore {
           s.streamingText = "";
           s.streamingThinking = "";
           s.pendingPermissions = [];
+          s.mcpServers = [];
           s.totalCost = 0;
           s.totalTurns = 0;
         }),
@@ -270,6 +285,7 @@ export function replayEvents(store: ChatStore, events: SSEEvent[]): void {
         break;
       case "session_init":
         s.setSdkSessionId(data.sdkSessionId);
+        if (data.mcpServers) s.setMcpServers(data.mcpServers);
         break;
       case "thinking_delta":
         s.appendStreamingThinking(data.text);

--- a/packages/react/src/use-agent.ts
+++ b/packages/react/src/use-agent.ts
@@ -81,8 +81,9 @@ export function useAgent(store: ChatStore, config?: UseAgentConfig): UseAgentRet
     abortedRef.current = false;
 
     es.addEventListener("session_init", (e) => {
-      const { sdkSessionId: id } = JSON.parse(e.data);
+      const { sdkSessionId: id, mcpServers } = JSON.parse(e.data);
       store.getState().setSdkSessionId(id);
+      if (mcpServers) store.getState().setMcpServers(mcpServers);
     });
 
     es.addEventListener("message_start", () => {

--- a/packages/server/src/translator.test.ts
+++ b/packages/server/src/translator.test.ts
@@ -353,6 +353,10 @@ describe("MessageTranslator", () => {
         session_id: "sdk-abc-123",
         model: "claude-sonnet-4-20250514",
         tools: ["Read", "Write", "Bash"],
+        mcp_servers: [
+          { name: "github", status: "connected" },
+          { name: "db", status: "failed" },
+        ],
       },
       s,
     );
@@ -363,10 +367,40 @@ describe("MessageTranslator", () => {
           sdkSessionId: "sdk-abc-123",
           model: "claude-sonnet-4-20250514",
           tools: ["Read", "Write", "Bash"],
+          mcpServers: [
+            { name: "github", status: "connected" },
+            { name: "db", status: "failed" },
+          ],
         }),
       },
     ]);
     expect(s.sdkSessionId).toBe("sdk-abc-123");
+  });
+
+  it("emits empty mcpServers when system init has no mcp_servers", () => {
+    const t = new MessageTranslator();
+    const s = stubSession();
+    const events = t.translate(
+      {
+        type: "system",
+        subtype: "init",
+        session_id: "sdk-no-mcp",
+        model: "claude-sonnet-4-20250514",
+        tools: [],
+      },
+      s,
+    );
+    expect(events).toEqual([
+      {
+        event: "session_init",
+        data: JSON.stringify({
+          sdkSessionId: "sdk-no-mcp",
+          model: "claude-sonnet-4-20250514",
+          tools: [],
+          mcpServers: [],
+        }),
+      },
+    ]);
   });
 
   it("ignores non-init system messages", () => {

--- a/packages/server/src/translator.ts
+++ b/packages/server/src/translator.ts
@@ -189,6 +189,7 @@ export class MessageTranslator<TCtx> {
             sdkSessionId,
             model: message.model as string,
             tools: message.tools as string[],
+            mcpServers: (message.mcp_servers as Array<{ name: string; status: string }>) ?? [],
           };
           events.push({
             event: "session_init",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,10 +10,16 @@ export interface CustomEvent<T = unknown> {
   value: T;
 }
 
+export interface McpServerStatus {
+  name: string;
+  status: string;
+}
+
 export interface SessionInitEvent {
   sdkSessionId: string;
   model: string;
   tools: string[];
+  mcpServers: McpServerStatus[];
 }
 
 export interface SessionHistoryEntry {


### PR DESCRIPTION
## Summary
- Adds `McpServerStatus` type (`name` + `status`) to `@neeter/types`
- Extracts `mcp_servers` array from SDK system init message in the translator
- Threads through `SessionInitEvent` → SSE → `use-agent` → Zustand store
- Replay also populates `mcpServers` on session resume

Clients can now read `mcpServers` from the store to detect failed MCP server connections (e.g. show a warning banner).

## Test plan
- [x] Translator test: asserts `mcpServers` in session_init output, including fallback to `[]` when absent
- [x] Replay test: asserts store state includes `mcpServers` after replay
- [x] All 129 tests pass
- [x] `pnpm check && pnpm build && pnpm test` green

Closes #50