### PR TITLE
feat: support file checkpointing and rewind

### DIFF
--- a/packages/react/src/replay.test.ts
+++ b/packages/react/src/replay.test.ts
@@ -134,6 +134,19 @@ describe("replayEvents", () => {
     });
   });
 
+  it("replays checkpoint events", () => {
+    const store = createChatStore();
+    replayEvents(store, [
+      { event: "checkpoint", data: JSON.stringify({ userMessageUuid: "uuid-1" }) },
+      { event: "text_delta", data: JSON.stringify({ text: "Hi" }) },
+      { event: "turn_complete", data: JSON.stringify({ cost: 0, numTurns: 1 }) },
+      { event: "checkpoint", data: JSON.stringify({ userMessageUuid: "uuid-2" }) },
+    ]);
+
+    const { checkpoints } = store.getState();
+    expect(checkpoints).toEqual(["uuid-1", "uuid-2"]);
+  });
+
   it("handles empty events array", () => {
     const store = createChatStore();
     replayEvents(store, []);

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -18,6 +18,7 @@ interface ChatStoreState {
   streamingThinking: string;
   pendingPermissions: PermissionRequest[];
   mcpServers: McpServerStatus[];
+  checkpoints: string[];
   totalCost: number;
   totalTurns: number;
 }
@@ -41,6 +42,7 @@ interface ChatStoreActions {
   addPermissionRequest: (request: PermissionRequest) => void;
   removePermissionRequest: (requestId: string) => void;
   setMcpServers: (servers: McpServerStatus[]) => void;
+  addCheckpoint: (uuid: string) => void;
   addCost: (cost: number, turns: number) => void;
   cancelInflightToolCalls: () => void;
   reset: () => void;
@@ -78,6 +80,7 @@ export function createChatStore(): ChatStore {
       streamingThinking: "",
       pendingPermissions: [],
       mcpServers: [],
+      checkpoints: [],
       totalCost: 0,
       totalTurns: 0,
 
@@ -228,6 +231,11 @@ export function createChatStore(): ChatStore {
           s.mcpServers = servers;
         }),
 
+      addCheckpoint: (uuid) =>
+        set((s) => {
+          s.checkpoints.push(uuid);
+        }),
+
       addCost: (cost, turns) =>
         set((s) => {
           s.totalCost += cost;
@@ -263,6 +271,7 @@ export function createChatStore(): ChatStore {
           s.streamingThinking = "";
           s.pendingPermissions = [];
           s.mcpServers = [];
+          s.checkpoints = [];
           s.totalCost = 0;
           s.totalTurns = 0;
         }),
@@ -309,6 +318,9 @@ export function replayEvents(store: ChatStore, events: SSEEvent[]): void {
         } else {
           s.completeToolCall(data.toolUseId, data.result);
         }
+        break;
+      case "checkpoint":
+        s.addCheckpoint(data.userMessageUuid);
         break;
       case "turn_complete":
         s.flushStreamingThinking();

--- a/packages/react/src/use-agent.ts
+++ b/packages/react/src/use-agent.ts
@@ -2,6 +2,7 @@ import type {
   CustomEvent,
   PermissionRequest,
   PermissionResponse,
+  RewindFilesResult,
   SessionHistoryEntry,
   SSEEvent,
 } from "@neeter/types";
@@ -22,6 +23,10 @@ export interface UseAgentReturn {
   stopSession: () => Promise<void>;
   respondToPermission: (response: PermissionResponse) => Promise<void>;
   resumeSession: (options?: { fork?: boolean; sdkSessionId?: string }) => Promise<void>;
+  rewindSession: (
+    checkpointId: string,
+    options?: { dryRun?: boolean },
+  ) => Promise<RewindFilesResult>;
   newSession: () => Promise<void>;
   refreshHistory: () => Promise<void>;
 }
@@ -185,6 +190,11 @@ export function useAgent(store: ChatStore, config?: UseAgentConfig): UseAgentRet
       }
     });
 
+    es.addEventListener("checkpoint", (e) => {
+      const { userMessageUuid } = JSON.parse(e.data);
+      store.getState().addCheckpoint(userMessageUuid);
+    });
+
     if (onCustomEvent) {
       es.addEventListener("custom", (e) => {
         onCustomEvent(JSON.parse(e.data) as CustomEvent);
@@ -278,6 +288,19 @@ export function useAgent(store: ChatStore, config?: UseAgentConfig): UseAgentRet
     }
   }, [endpoint]);
 
+  const rewindSession = useCallback(
+    async (checkpointId: string, options?: { dryRun?: boolean }): Promise<RewindFilesResult> => {
+      if (!sessionId) return { canRewind: false, error: "No active session" };
+      const res = await fetch(`${endpoint}/sessions/${sessionId}/rewind`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userMessageId: checkpointId, dryRun: options?.dryRun }),
+      });
+      return res.json();
+    },
+    [sessionId, endpoint],
+  );
+
   const newSession = useCallback(async () => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -299,6 +322,7 @@ export function useAgent(store: ChatStore, config?: UseAgentConfig): UseAgentRet
     stopSession,
     respondToPermission,
     resumeSession,
+    rewindSession,
     newSession,
     refreshHistory,
   };

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -1,4 +1,4 @@
-import type { PermissionResponse, SSEEvent } from "@neeter/types";
+import type { PermissionResponse, RewindFilesRequest, SSEEvent } from "@neeter/types";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { type Session, type SessionManager, sessionMeta } from "./session.js";
@@ -14,6 +14,7 @@ const PERSISTED_EVENTS = new Set([
   "session_init",
   "session_error",
   "custom",
+  "checkpoint",
 ]);
 
 /**
@@ -156,6 +157,22 @@ export function createAgentRouter<TCtx>(config: {
 
     session.lastActivityAt = Date.now();
     return c.json({ ok: true });
+  });
+
+  app.post(`${basePath}/sessions/:id/rewind`, async (c) => {
+    const session = sessions.get(c.req.param("id"));
+    if (!session) return c.json({ error: "Session not found" }, 404);
+
+    const body = await c.req.json<RewindFilesRequest>();
+    if (!body.userMessageId?.trim()) {
+      return c.json({ error: "userMessageId is required" }, 400);
+    }
+
+    const result = await session.messageIterator.rewindFiles(body.userMessageId.trim(), {
+      dryRun: body.dryRun,
+    });
+    session.lastActivityAt = Date.now();
+    return c.json(result);
   });
 
   app.post(`${basePath}/sessions/:id/abort`, (c) => {

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -108,15 +108,17 @@ describe("SessionInit passthrough", () => {
     }));
     mgr.create();
 
-    expect(lastQueryOptions?.env).toEqual({ CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: "1" });
+    expect(lastQueryOptions?.env).toMatchObject({
+      CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: "1",
+    });
   });
 
-  it("omits extraArgs and env when not provided", () => {
+  it("passes empty extraArgs and process.env when not configured", () => {
     const mgr = createManager();
     mgr.create();
 
-    expect(lastQueryOptions).not.toHaveProperty("extraArgs");
-    expect(lastQueryOptions).not.toHaveProperty("env");
+    expect(lastQueryOptions?.extraArgs).toEqual({});
+    expect(lastQueryOptions?.env).toBeDefined();
   });
 });
 

--- a/packages/server/src/session.ts
+++ b/packages/server/src/session.ts
@@ -2,14 +2,13 @@ import {
   type HookCallbackMatcher,
   type HookEvent,
   type McpServerConfig,
+  type Query,
   query,
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { SessionHistoryEntry, SessionStore, SSEEvent, UserQuestion } from "@neeter/types";
 import { PermissionGate } from "./permission-gate.js";
 import { PushChannel } from "./push-channel.js";
-
-type SDKMessage = ReturnType<typeof query> extends AsyncGenerator<infer T> ? T : never;
 
 function userMessage(content: string): SDKUserMessage {
   return {
@@ -47,6 +46,8 @@ export interface SessionInit<TCtx> {
   extraArgs?: Record<string, string | null>;
   /** Environment variables forwarded to the Claude Code subprocess. */
   env?: Record<string, string | undefined>;
+  /** Track file changes and enable rewinding to previous states. Off by default. */
+  enableFileCheckpointing?: boolean;
 }
 
 export interface ResumeOptions {
@@ -61,7 +62,7 @@ export interface Session<TCtx> {
   cwd?: string;
   context: TCtx;
   pushMessage(text: string): void;
-  messageIterator: AsyncIterable<SDKMessage>;
+  messageIterator: Query;
   permissionGate: PermissionGate;
   abort(): void;
   createdAt: number;
@@ -247,8 +248,18 @@ export class SessionManager<TCtx> {
         ...(init.cwd ? { cwd: init.cwd } : {}),
         ...(init.disallowedTools ? { disallowedTools: init.disallowedTools } : {}),
         ...(init.hooks ? { hooks: init.hooks } : {}),
-        ...(init.extraArgs ? { extraArgs: init.extraArgs } : {}),
-        ...(init.env ? { env: init.env } : {}),
+        ...(init.enableFileCheckpointing ? { enableFileCheckpointing: true } : {}),
+        extraArgs: {
+          ...(init.enableFileCheckpointing ? { "replay-user-messages": null } : {}),
+          ...init.extraArgs,
+        },
+        env: {
+          ...process.env,
+          ...(init.enableFileCheckpointing
+            ? { CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: "1" }
+            : {}),
+          ...init.env,
+        },
         ...extraQueryOptions,
       },
     });

--- a/packages/server/src/translator.test.ts
+++ b/packages/server/src/translator.test.ts
@@ -8,7 +8,9 @@ function stubSession(ctx = {}): Session<Record<string, unknown>> {
     id: "sess-1",
     context: ctx,
     pushMessage: () => {},
-    messageIterator: (async function* () {})(),
+    messageIterator: (async function* () {})() as unknown as Session<
+      Record<string, unknown>
+    >["messageIterator"],
     permissionGate: new PermissionGate(),
     abort: () => {},
     createdAt: Date.now(),
@@ -401,6 +403,59 @@ describe("MessageTranslator", () => {
         }),
       },
     ]);
+  });
+
+  it("emits checkpoint event when user message has uuid", () => {
+    const t = new MessageTranslator();
+    t.translate(
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "t-cp", name: "Bash", input: {} }] },
+      },
+      session,
+    );
+    const events = t.translate(
+      {
+        type: "user",
+        uuid: "cp-uuid-123",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t-cp", content: "done" }],
+        },
+      },
+      session,
+    );
+    expect(events[0]).toEqual({
+      event: "checkpoint",
+      data: JSON.stringify({ userMessageUuid: "cp-uuid-123" }),
+    });
+    expect(events[1]).toEqual({
+      event: "tool_result",
+      data: JSON.stringify({ toolUseId: "t-cp", result: "done", isError: false }),
+    });
+  });
+
+  it("does not emit checkpoint when user message has no uuid", () => {
+    const t = new MessageTranslator();
+    t.translate(
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "t-no", name: "Read", input: {} }] },
+      },
+      session,
+    );
+    const events = t.translate(
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t-no", content: "ok" }],
+        },
+      },
+      session,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe("tool_result");
   });
 
   it("ignores non-init system messages", () => {

--- a/packages/server/src/translator.ts
+++ b/packages/server/src/translator.ts
@@ -146,6 +146,13 @@ export class MessageTranslator<TCtx> {
       }
 
       case "user": {
+        const uuid = message.uuid as string | undefined;
+        if (uuid) {
+          events.push({
+            event: "checkpoint",
+            data: JSON.stringify({ userMessageUuid: uuid }),
+          });
+        }
         const msg = (message as { message?: { role: string; content: unknown } }).message;
         if (Array.isArray(msg?.content)) {
           for (const block of msg.content) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -97,6 +97,25 @@ export interface UserQuestionResponse {
 
 export type PermissionResponse = ToolApprovalResponse | UserQuestionResponse;
 
+// --- File Checkpointing ---
+
+export interface CheckpointEvent {
+  userMessageUuid: string;
+}
+
+export interface RewindFilesRequest {
+  userMessageId: string;
+  dryRun?: boolean;
+}
+
+export interface RewindFilesResult {
+  canRewind: boolean;
+  error?: string;
+  filesChanged?: string[];
+  insertions?: number;
+  deletions?: number;
+}
+
 // --- Persistence ---
 
 export interface SessionRecord {


### PR DESCRIPTION
## Summary
- Add `rewindSession()` to `useAgentContext` for rewinding and previewing file checkpoints
- Add `enableFileCheckpointing` option to `SessionManager` factory config
- Add `RewindFilesResult` and `FileCheckpoint` types to `@neeter/types`
- Plumb `/sessions/:id/rewind` API route through server and React hook
- Export `createSandboxHook` from `@neeter/server` for restricting file access

## Test plan
- [x] `pnpm check && pnpm build && pnpm test` passes
- [ ] Manual testing via code-workbench example (tracked separately)

Closes #46