### PR TITLE
feat: support resumeSessionAt for conversation truncation on resume

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -12,7 +12,7 @@ For usage examples, see the [Server Guide](server.md) and [Client Guide](client.
 | `SessionManagerOptions` | Constructor options — `idleTimeoutMs`, `store` |
 | `Session<TCtx>` | A single session — `id`, `sdkSessionId`, `context`, `pushMessage()`, `permissionGate`, `abort()` |
 | `SessionInit<TCtx>` | Factory return type — `model`, `systemPrompt`, `permissionMode`, `mcpServers`, `extraArgs`, `env`, etc. |
-| `ResumeOptions` | Options for `SessionManager.resume()` — `sdkSessionId`, `forkSession` |
+| `ResumeOptions` | Options for `SessionManager.resume()` — `sdkSessionId`, `forkSession`, `resumeSessionAt` |
 | `sessionMeta(session)` | Extract a `SessionHistoryEntry` from a `Session` |
 | `createJsonSessionStore(dataDir)` | File-based `SessionStore` using append-only JSONL + JSON metadata |
 | `MessageTranslator<TCtx>` | Converts SDK messages to SSE events |
@@ -33,7 +33,7 @@ For usage examples, see the [Server Guide](server.md) and [Client Guide](client.
 | `useChatStore(selector)` | Zustand selector hook into chat state |
 | `createChatStore()` | Creates a vanilla Zustand store (for advanced use) |
 | `useAgent(store, config?)` | SSE connection hook (used internally by `AgentProvider`). Config: `endpoint`, `resumeSessionId`, `onCustomEvent` |
-| `replayEvents(store, events)` | Reconstruct chat store state from persisted `SSEEvent[]` |
+| `replayEvents(store, events, options?)` | Reconstruct chat store state from persisted `SSEEvent[]`. Pass `stopAtCheckpoint` to truncate at a checkpoint |
 | `MessageList` | Auto-scrolling message list with pending permissions and thinking indicator |
 | `TextMessage` | Markdown-rendered message bubble |
 | `ChatInput` | Textarea + send/stop button (accepts `onStop`, `isStreaming`) |

--- a/packages/react/src/replay.test.ts
+++ b/packages/react/src/replay.test.ts
@@ -152,4 +152,62 @@ describe("replayEvents", () => {
     replayEvents(store, []);
     expect(store.getState().messages).toHaveLength(0);
   });
+
+  it("stops replay at the specified checkpoint", () => {
+    const store = createChatStore();
+    replayEvents(
+      store,
+      [
+        { event: "user_message", data: JSON.stringify({ text: "First" }) },
+        { event: "checkpoint", data: JSON.stringify({ userMessageUuid: "cp-1" }) },
+        { event: "text_delta", data: JSON.stringify({ text: "Reply 1" }) },
+        { event: "turn_complete", data: JSON.stringify({ cost: 0.01, numTurns: 1 }) },
+        { event: "user_message", data: JSON.stringify({ text: "Second" }) },
+        { event: "checkpoint", data: JSON.stringify({ userMessageUuid: "cp-2" }) },
+        { event: "text_delta", data: JSON.stringify({ text: "Reply 2" }) },
+        { event: "turn_complete", data: JSON.stringify({ cost: 0.01, numTurns: 1 }) },
+      ],
+      { stopAtCheckpoint: "cp-1" },
+    );
+
+    const { messages, checkpoints, totalCost } = store.getState();
+    expect(messages).toHaveLength(2);
+    expect(messages[0].content).toBe("First");
+    expect(messages[1].content).toBe("Reply 1");
+    expect(checkpoints).toEqual(["cp-1"]);
+    expect(totalCost).toBe(0.01);
+  });
+
+  it("replays everything when stopAtCheckpoint is not provided", () => {
+    const store = createChatStore();
+    replayEvents(store, [
+      { event: "user_message", data: JSON.stringify({ text: "First" }) },
+      { event: "checkpoint", data: JSON.stringify({ userMessageUuid: "cp-1" }) },
+      { event: "text_delta", data: JSON.stringify({ text: "Reply 1" }) },
+      { event: "turn_complete", data: JSON.stringify({ cost: 0.01, numTurns: 1 }) },
+      { event: "user_message", data: JSON.stringify({ text: "Second" }) },
+      { event: "text_delta", data: JSON.stringify({ text: "Reply 2" }) },
+      { event: "turn_complete", data: JSON.stringify({ cost: 0.01, numTurns: 1 }) },
+    ]);
+
+    expect(store.getState().messages).toHaveLength(4);
+    expect(store.getState().totalCost).toBe(0.02);
+  });
+
+  it("replays everything when stopAtCheckpoint does not match", () => {
+    const store = createChatStore();
+    replayEvents(
+      store,
+      [
+        { event: "user_message", data: JSON.stringify({ text: "First" }) },
+        { event: "checkpoint", data: JSON.stringify({ userMessageUuid: "cp-1" }) },
+        { event: "text_delta", data: JSON.stringify({ text: "Reply 1" }) },
+        { event: "turn_complete", data: JSON.stringify({ cost: 0.01, numTurns: 1 }) },
+      ],
+      { stopAtCheckpoint: "nonexistent" },
+    );
+
+    expect(store.getState().messages).toHaveLength(2);
+    expect(store.getState().totalCost).toBe(0.01);
+  });
 });

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -284,8 +284,15 @@ export function createChatStore(): ChatStore {
  * store actions as the live SSE stream, so rendering is identical.
  * Call before connecting the EventSource (e.g. during session resume).
  */
-export function replayEvents(store: ChatStore, events: SSEEvent[]): void {
+export function replayEvents(
+  store: ChatStore,
+  events: SSEEvent[],
+  options?: { stopAtCheckpoint?: string },
+): void {
   const s = store.getState();
+  const stopAt = options?.stopAtCheckpoint;
+  let foundTarget = false;
+
   for (const evt of events) {
     const data = JSON.parse(evt.data);
     switch (evt.event) {
@@ -321,16 +328,19 @@ export function replayEvents(store: ChatStore, events: SSEEvent[]): void {
         break;
       case "checkpoint":
         s.addCheckpoint(data.userMessageUuid);
+        if (stopAt && data.userMessageUuid === stopAt) foundTarget = true;
         break;
       case "turn_complete":
         s.flushStreamingThinking();
         s.flushStreamingText();
         s.addCost(data.cost ?? 0, data.numTurns ?? 0);
+        if (foundTarget) return;
         break;
       case "session_error":
         s.flushStreamingThinking();
         s.flushStreamingText();
         s.addSystemMessage(`Session ended: ${data.subtype}`);
+        if (foundTarget) return;
         break;
     }
   }

--- a/packages/react/src/use-agent.ts
+++ b/packages/react/src/use-agent.ts
@@ -22,7 +22,11 @@ export interface UseAgentReturn {
   sendMessage: (text: string) => Promise<void>;
   stopSession: () => Promise<void>;
   respondToPermission: (response: PermissionResponse) => Promise<void>;
-  resumeSession: (options?: { fork?: boolean; sdkSessionId?: string }) => Promise<void>;
+  resumeSession: (options?: {
+    fork?: boolean;
+    sdkSessionId?: string;
+    resumeSessionAt?: string;
+  }) => Promise<void>;
   rewindSession: (
     checkpointId: string,
     options?: { dryRun?: boolean },
@@ -244,7 +248,7 @@ export function useAgent(store: ChatStore, config?: UseAgentConfig): UseAgentRet
   );
 
   const resumeSession = useCallback(
-    async (options?: { fork?: boolean; sdkSessionId?: string }) => {
+    async (options?: { fork?: boolean; sdkSessionId?: string; resumeSessionAt?: string }) => {
       const targetSdkSessionId = options?.sdkSessionId ?? store.getState().sdkSessionId;
       if (!targetSdkSessionId) return;
 
@@ -259,7 +263,9 @@ export function useAgent(store: ChatStore, config?: UseAgentConfig): UseAgentRet
         const eventsRes = await fetch(`${endpoint}/sessions/replay/${targetSdkSessionId}`);
         if (eventsRes.ok) {
           const events: SSEEvent[] = await eventsRes.json();
-          replayEvents(store, events);
+          replayEvents(store, events, {
+            stopAtCheckpoint: options?.resumeSessionAt,
+          });
         }
       } catch {
         /* replay is best-effort */
@@ -271,6 +277,7 @@ export function useAgent(store: ChatStore, config?: UseAgentConfig): UseAgentRet
         body: JSON.stringify({
           sdkSessionId: targetSdkSessionId,
           forkSession: options?.fork,
+          resumeSessionAt: options?.resumeSessionAt,
         }),
       });
       const data = await res.json();

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -43,13 +43,18 @@ export function createAgentRouter<TCtx>(config: {
   });
 
   app.post(`${basePath}/sessions/resume`, async (c) => {
-    const body = await c.req.json<{ sdkSessionId: string; forkSession?: boolean }>();
+    const body = await c.req.json<{
+      sdkSessionId: string;
+      forkSession?: boolean;
+      resumeSessionAt?: string;
+    }>();
     if (!body.sdkSessionId?.trim()) {
       return c.json({ error: "sdkSessionId is required" }, 400);
     }
     const session = sessions.resume({
       sdkSessionId: body.sdkSessionId.trim(),
       forkSession: body.forkSession,
+      resumeSessionAt: body.resumeSessionAt?.trim() || undefined,
     });
     return c.json({ sessionId: session.id });
   });

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -84,6 +84,34 @@ describe("SessionManager.resume", () => {
     expect(resumed.id).not.toBe(original.id);
     expect(mgr.get(resumed.id)).toBe(resumed);
   });
+
+  it("passes resumeSessionAt to query options", () => {
+    const mgr = createManager();
+    mgr.resume({ sdkSessionId: "sdk-abc", resumeSessionAt: "uuid-cp-1" });
+
+    expect(lastQueryOptions?.resume).toBe("sdk-abc");
+    expect(lastQueryOptions?.resumeSessionAt).toBe("uuid-cp-1");
+  });
+
+  it("omits resumeSessionAt when not provided", () => {
+    const mgr = createManager();
+    mgr.resume({ sdkSessionId: "sdk-abc" });
+
+    expect(lastQueryOptions?.resumeSessionAt).toBeUndefined();
+  });
+
+  it("passes both forkSession and resumeSessionAt", () => {
+    const mgr = createManager();
+    mgr.resume({
+      sdkSessionId: "sdk-abc",
+      forkSession: true,
+      resumeSessionAt: "uuid-cp-1",
+    });
+
+    expect(lastQueryOptions?.resume).toBe("sdk-abc");
+    expect(lastQueryOptions?.forkSession).toBe(true);
+    expect(lastQueryOptions?.resumeSessionAt).toBe("uuid-cp-1");
+  });
 });
 
 describe("SessionInit passthrough", () => {

--- a/packages/server/src/session.ts
+++ b/packages/server/src/session.ts
@@ -53,6 +53,7 @@ export interface SessionInit<TCtx> {
 export interface ResumeOptions {
   sdkSessionId: string;
   forkSession?: boolean;
+  resumeSessionAt?: string;
 }
 
 export interface Session<TCtx> {
@@ -123,6 +124,7 @@ export class SessionManager<TCtx> {
     return this.buildSession(init, {
       resume: options.sdkSessionId,
       ...(options.forkSession ? { forkSession: true } : {}),
+      ...(options.resumeSessionAt ? { resumeSessionAt: options.resumeSessionAt } : {}),
     });
   }
 
@@ -179,7 +181,7 @@ export class SessionManager<TCtx> {
 
   private buildSession(
     init: SessionInit<TCtx>,
-    extraQueryOptions?: { resume?: string; forkSession?: boolean },
+    extraQueryOptions?: { resume?: string; forkSession?: boolean; resumeSessionAt?: string },
   ): Session<TCtx> {
     const id = crypto.randomUUID();
     const channel = new PushChannel<SDKUserMessage>();


### PR DESCRIPTION
## Summary
- Threads `resumeSessionAt` through server `resume()`, router POST `/sessions/resume`, react `resumeSession()` hook, and store `replayEvents()` so the SDK truncates conversation history to a specific checkpoint UUID
- Replay stops after the matching checkpoint's `turn_complete` so the UI matches what the agent remembers

## Test plan
- [x] 6 new unit tests (3 server, 3 react replay) — 138 total passing
- [x] E2E verified: sent ALPHA-7 then BRAVO-9, resumed at first checkpoint, agent only remembered ALPHA-7

Closes #73