### PR TITLE
fix: validate all path-like fields in createSandboxHook

### DIFF
--- a/packages/server/src/hooks.test.ts
+++ b/packages/server/src/hooks.test.ts
@@ -86,6 +86,63 @@ describe("createSandboxHook", () => {
     expect(result).toEqual({});
   });
 
+  it("blocks Glob pattern with absolute path outside sandbox", async () => {
+    const result = await hook(preToolUseInput({ pattern: "/etc/**/*.txt" }, "Glob"), "tool-1", {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Access outside sandbox directory is not allowed",
+      },
+    });
+  });
+
+  it("blocks Glob pattern with .. traversal", async () => {
+    const result = await hook(preToolUseInput({ pattern: "../../**/*.jsx" }, "Glob"), "tool-1", {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Access outside sandbox directory is not allowed",
+      },
+    });
+  });
+
+  it("allows Glob pattern inside sandbox", async () => {
+    const result = await hook(
+      preToolUseInput({ pattern: `${sandboxDir}/**/*.html` }, "Glob"),
+      "tool-1",
+      { signal: AbortSignal.timeout(5000) },
+    );
+    expect(result).toEqual({});
+  });
+
+  it("allows Glob with relative pattern (no traversal)", async () => {
+    const result = await hook(preToolUseInput({ pattern: "**/*.jsx" }, "Glob"), "tool-1", {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(result).toEqual({});
+  });
+
+  it("blocks notebook_path outside sandbox", async () => {
+    const result = await hook(
+      preToolUseInput({ notebook_path: "/home/user/notebook.ipynb" }, "NotebookEdit"),
+      "tool-1",
+      { signal: AbortSignal.timeout(5000) },
+    );
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Access outside sandbox directory is not allowed",
+      },
+    });
+  });
+
   it("checks the path field (used by Glob/Grep)", async () => {
     const result = await hook(
       preToolUseInput({ path: "/home/user/secrets", pattern: "*.txt" }),

--- a/packages/server/src/hooks.ts
+++ b/packages/server/src/hooks.ts
@@ -66,18 +66,50 @@ export function createSandboxHook(
           }
 
           const toolInput = preInput.tool_input as Record<string, unknown>;
-          const filePath = (toolInput.file_path ?? toolInput.path) as string | undefined;
-          if (!filePath) return {};
-          const resolved = resolvePath(filePath);
-          if (resolved !== normalizedDir && !resolved.startsWith(`${normalizedDir}/`)) {
-            return {
-              hookSpecificOutput: {
-                hookEventName: input.hook_event_name,
-                permissionDecision: "deny",
-                permissionDecisionReason: "Access outside sandbox directory is not allowed",
-              },
-            };
+
+          // Collect all path-like fields from tool input.
+          // - file_path: Read, Write, Edit
+          // - path: Glob (search directory), Grep (search directory)
+          // - notebook_path: NotebookEdit
+          const pathFields = ["file_path", "path", "notebook_path"] as const;
+          for (const field of pathFields) {
+            const value = toolInput[field] as string | undefined;
+            if (!value) continue;
+            const resolved = resolvePath(value);
+            if (resolved !== normalizedDir && !resolved.startsWith(`${normalizedDir}/`)) {
+              return {
+                hookSpecificOutput: {
+                  hookEventName: input.hook_event_name,
+                  permissionDecision: "deny",
+                  permissionDecisionReason: "Access outside sandbox directory is not allowed",
+                },
+              };
+            }
           }
+
+          // Glob's `pattern` can embed absolute paths or ".." traversals
+          // (e.g. "/etc/**" or "../../**/*.jsx"). Extract the non-glob prefix
+          // and validate it stays within the sandbox.
+          if (preInput.tool_name === "Glob") {
+            const pattern = toolInput.pattern as string | undefined;
+            if (pattern) {
+              const prefixMatch = pattern.match(/^([^*?{[]*)\//);
+              const prefix = prefixMatch ? prefixMatch[1] : pattern;
+              if (prefix.startsWith("/") || prefix.startsWith("..")) {
+                const resolved = resolvePath(prefix);
+                if (resolved !== normalizedDir && !resolved.startsWith(`${normalizedDir}/`)) {
+                  return {
+                    hookSpecificOutput: {
+                      hookEventName: input.hook_event_name,
+                      permissionDecision: "deny",
+                      permissionDecisionReason: "Access outside sandbox directory is not allowed",
+                    },
+                  };
+                }
+              }
+            }
+          }
+
           return {};
         },
       ],


### PR DESCRIPTION
## Summary
- `createSandboxHook` now checks `notebook_path` (NotebookEdit) and Glob's `pattern` field for absolute paths / `..` traversals
- Refactored single `file_path`/`path` check into a loop over all path-like fields

## Test plan
- [x] 5 new tests covering Glob pattern traversal, sandbox-scoped patterns, and notebook_path
- [x] All 146 tests pass
- [x] `pnpm check && pnpm build && pnpm test` clean

Closes #76