### PR TITLE
feat(server): widen systemPrompt to support preset/append object form

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -19,6 +19,30 @@
 | `POST` | `/api/sessions/:id/permissions` | Respond to a permission request (see [Permissions](#permissions)) |
 | `POST` | `/api/sessions/:id/abort` | Abort the current agent turn |
 
+## System prompt
+
+`systemPrompt` accepts a plain string or the Claude Code preset object. The preset includes built-in safety instructions, tool-usage guidance, and environment context — use `append` to layer on your own instructions:
+
+```typescript
+// Plain string — full control, no built-in behavior
+const sessions = new SessionManager(() => ({
+  context: {},
+  model: "claude-sonnet-4-5-20250929",
+  systemPrompt: "You are a helpful assistant.",
+}));
+
+// Preset — Claude Code defaults + your additions
+const sessions = new SessionManager(() => ({
+  context: {},
+  model: "claude-sonnet-4-5-20250929",
+  systemPrompt: {
+    type: "preset",
+    preset: "claude_code",
+    append: "You are a helpful assistant that can look up Pokémon.",
+  },
+}));
+```
+
 ## Extended thinking
 
 Enable Claude's chain-of-thought reasoning by setting `thinking` in your session config:

--- a/examples/basic-chat/server.ts
+++ b/examples/basic-chat/server.ts
@@ -9,7 +9,11 @@ delete process.env.CLAUDECODE;
 const sessions = new SessionManager(() => ({
   context: {},
   model: "claude-sonnet-4-20250514",
-  systemPrompt: "You are a helpful assistant that can look up Pokémon.",
+  systemPrompt: {
+    type: "preset",
+    preset: "claude_code",
+    append: "You are a helpful assistant that can look up Pokémon.",
+  },
   mcpServers: { pokemon: createPokemonServer() },
   allowedTools: ["mcp__pokemon__*"],
 }));

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -17,7 +17,7 @@ function createManager(
   factory?: (original?: { context: { n: number } }) => {
     context: { n: number };
     model: string;
-    systemPrompt: string;
+    systemPrompt: string | { type: "preset"; preset: "claude_code"; append?: string };
   },
 ) {
   return new SessionManager<{ n: number }>(

--- a/packages/server/src/session.ts
+++ b/packages/server/src/session.ts
@@ -26,7 +26,7 @@ export interface SessionInit<TCtx> {
   context: TCtx;
   /** Claude model ID (e.g. `"claude-sonnet-4-5-20250929"`). */
   model: string;
-  systemPrompt: string;
+  systemPrompt: string | { type: "preset"; preset: "claude_code"; append?: string };
   /** MCP servers keyed by name — the name becomes the middle segment of tool names (`mcp__{name}__{tool}`). */
   mcpServers?: Record<string, McpServerConfig>;
   tools?: string[] | { type: "preset"; preset: "claude_code" };


### PR DESCRIPTION
## Summary
- Widens `SessionInit.systemPrompt` from `string` to `string | { type: "preset"; preset: "claude_code"; append?: string }` so users can opt into the Claude Code preset with built-in safety instructions, tool-usage guidance, and environment context
- Updates `basic-chat` example to demonstrate the preset + append pattern
- Adds a "System prompt" section to the Server Guide showing both forms

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` — 162/162 tests pass

Closes #44