### PR TITLE
fix(react): display activeForm for in-progress todo items

### DIFF
--- a/packages/react/src/widgets/TodoWriteWidget.tsx
+++ b/packages/react/src/widgets/TodoWriteWidget.tsx
@@ -42,7 +42,7 @@ function TodoList({ todos }: { todos: TodoItem[] }) {
                   : "text-muted-foreground"
             }
           >
-            {todo.content}
+            {todo.status === "in_progress" && todo.activeForm ? todo.activeForm : todo.content}
           </span>
         </div>
       ))}


### PR DESCRIPTION
## Summary
- In-progress todo items now display `activeForm` text instead of always showing imperative `content`

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` — 162/162 tests pass
- [x] Manual: confirmed in-progress items render `activeForm`, completed/pending items render `content`

Closes #41