### PR TITLE
feat(server): support image/multimodal content in messages

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,6 +14,7 @@ For usage examples, see the [Server Guide](server.md) and [Client Guide](client.
 | `SessionInit<TCtx>` | Factory return type — `model`, `systemPrompt`, `permissionMode`, `mcpServers`, `extraArgs`, `env`, etc. |
 | `ResumeOptions` | Options for `SessionManager.resume()` — `sdkSessionId`, `forkSession`, `resumeSessionAt` |
 | `sessionMeta(session)` | Extract a `SessionHistoryEntry` from a `Session` |
+| `extractText(content)` | Pull the text portion from a `UserMessageContent` value |
 | `createJsonSessionStore(dataDir)` | File-based `SessionStore` using append-only JSONL + JSON metadata |
 | `MessageTranslator<TCtx>` | Converts SDK messages to SSE events |
 | `TranslatorConfig<TCtx>` | Translator options — `onToolResult` hook |
@@ -65,6 +66,11 @@ Re-exported from both `@neeter/server` and `@neeter/react`:
 | `WidgetRegistration<TResult>` | Widget registration — `toolName`, `label`, `richLabel?`, `inputRenderer?`, `component` |
 | `ChatStore` | `StoreApi<ChatStoreShape>` — vanilla Zustand store |
 | `ChatStoreShape` | Full state + actions interface (includes `totalCost`, `totalTurns`, `totalInputTokens`, `totalOutputTokens`, `modelUsage`, `lastStopReason`) |
+| `TextBlock` | `{ type: "text", text: string }` — text content block |
+| `Base64ImageSource` | `{ type: "base64", media_type, data }` — base64-encoded image source |
+| `ImageBlock` | `{ type: "image", source: Base64ImageSource }` — image content block |
+| `ContentBlock` | `TextBlock \| ImageBlock` — single content block |
+| `UserMessageContent` | `string \| ContentBlock[]` — content for a user message |
 | `CustomEvent<T>` | `{ name: string, value: T }` — structured app-level event |
 | `SessionInitEvent` | `{ sdkSessionId, model, tools }` — session initialization payload |
 | `SessionHistoryEntry` | `{ sdkSessionId, description, createdAt, lastActivityAt }` — session metadata |

--- a/docs/server.md
+++ b/docs/server.md
@@ -14,7 +14,7 @@
 | `POST` | `/api/sessions/resume` | Resume or fork a session by SDK session ID |
 | `GET` | `/api/sessions/history` | List previous sessions |
 | `GET` | `/api/sessions/replay/:sdkSessionId` | Load persisted events for UI replay |
-| `POST` | `/api/sessions/:id/messages` | Send `{ text }` to a session |
+| `POST` | `/api/sessions/:id/messages` | Send a message — text or multimodal content |
 | `GET` | `/api/sessions/:id/events` | SSE stream of agent events |
 | `POST` | `/api/sessions/:id/permissions` | Respond to a permission request (see [Permissions](#permissions)) |
 | `POST` | `/api/sessions/:id/abort` | Abort the current agent turn |
@@ -67,6 +67,59 @@ When thinking is enabled, the Agent SDK suppresses `StreamEvent` messages — th
 <p>
   <img src="assets/thinking.png" alt="Extended thinking block with chain-of-thought reasoning" width="600" />
 </p>
+
+## Multimodal messages
+
+The messages endpoint accepts plain text or structured content arrays with text and image blocks:
+
+```bash
+# Plain text (unchanged)
+curl -X POST /api/sessions/:id/messages \
+  -d '{ "text": "Hello" }'
+
+# Text + image
+curl -X POST /api/sessions/:id/messages \
+  -d '{
+    "content": [
+      { "type": "text", "text": "Describe this diagram" },
+      {
+        "type": "image",
+        "source": {
+          "type": "base64",
+          "media_type": "image/png",
+          "data": "<base64-encoded data>"
+        }
+      }
+    ]
+  }'
+```
+
+When `content` is provided it takes precedence over `text`. Supported image media types: `image/jpeg`, `image/png`, `image/gif`, `image/webp`.
+
+On the server side, `session.pushMessage()` now accepts `string | ContentBlock[]`:
+
+```typescript
+// Text-only (backward compatible)
+session.pushMessage("Hello");
+
+// Multimodal
+session.pushMessage([
+  { type: "text", text: "What's in this image?" },
+  {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: pngBase64 },
+  },
+]);
+```
+
+The `extractText()` helper pulls the text portion from either form — useful for display or logging:
+
+```typescript
+import { extractText } from "@neeter/server";
+
+extractText("Hello");                        // "Hello"
+extractText([{ type: "text", text: "Hi" }]); // "Hi"
+```
 
 ## Session context
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -45,6 +45,29 @@ app.route("/", createAgentRouter({ sessions, translator }));
 serve({ fetch: app.fetch, port: 3000 });
 ```
 
+## Multimodal messages
+
+Send images alongside text via the messages endpoint:
+
+```typescript
+// POST /api/sessions/:id/messages
+{
+  "content": [
+    { "type": "text", "text": "Describe this image" },
+    {
+      "type": "image",
+      "source": {
+        "type": "base64",
+        "media_type": "image/png",
+        "data": "<base64>"
+      }
+    }
+  ]
+}
+```
+
+Plain `{ "text": "..." }` payloads continue to work as before. See the [Server Guide](https://github.com/quantumleeps/neeter/blob/main/docs/server.md#multimodal-messages) for details.
+
 ## Examples
 
 | Example | Description |

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,10 +1,19 @@
-export type { CustomEvent, SSEEvent } from "@neeter/types";
+export type {
+  Base64ImageSource,
+  ContentBlock,
+  CustomEvent,
+  ImageBlock,
+  SSEEvent,
+  TextBlock,
+  UserMessageContent,
+} from "@neeter/types";
 export { createSandboxHook } from "./hooks.js";
 export { createJsonSessionStore } from "./json-store.js";
 export { PermissionGate } from "./permission-gate.js";
 export { PushChannel } from "./push-channel.js";
 export { createAgentRouter } from "./router.js";
 export {
+  extractText,
   type ResumeOptions,
   type Session,
   type SessionInit,

--- a/packages/server/src/router.test.ts
+++ b/packages/server/src/router.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: ({ options }: { options: Record<string, unknown> }) => {
+    void options;
+    return (async function* () {})();
+  },
+}));
+
+import type { ContentBlock } from "@neeter/types";
+import { createAgentRouter } from "./router.js";
+import { SessionManager } from "./session.js";
+import { MessageTranslator } from "./translator.js";
+
+function createApp() {
+  const sessions = new SessionManager<Record<string, unknown>>(() => ({
+    context: {},
+    model: "test",
+    systemPrompt: "test",
+  }));
+  const translator = new MessageTranslator();
+  const app = createAgentRouter({ sessions, translator });
+  return { app, sessions };
+}
+
+async function postMessage(
+  app: ReturnType<typeof createApp>["app"],
+  sessionId: string,
+  body: Record<string, unknown>,
+) {
+  return app.request(`/api/sessions/${sessionId}/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /sessions/:id/messages", () => {
+  it("accepts a plain text message", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const res = await postMessage(app, session.id, { text: "Hello" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("accepts a content array with text + image blocks", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const content: ContentBlock[] = [
+      { type: "text", text: "Describe this" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "iVBOR..." },
+      },
+    ];
+    const res = await postMessage(app, session.id, { content });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("prefers content over text when both provided", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const content: ContentBlock[] = [{ type: "text", text: "From content array" }];
+    const res = await postMessage(app, session.id, {
+      text: "From text field",
+      content,
+    });
+    expect(res.status).toBe(200);
+    // firstPrompt should come from the content array
+    expect(session.firstPrompt).toBe("From content array");
+  });
+
+  it("rejects empty content array", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const res = await postMessage(app, session.id, { content: [] });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/must not be empty/i);
+  });
+
+  it("rejects text blocks with empty text", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const res = await postMessage(app, session.id, {
+      content: [{ type: "text", text: "  " }],
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/non-empty text/i);
+  });
+
+  it("rejects image blocks without base64 source", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const res = await postMessage(app, session.id, {
+      content: [{ type: "image", source: { type: "url", url: "https://example.com/img.png" } }],
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/base64 source/i);
+  });
+
+  it("rejects unsupported image media types", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const res = await postMessage(app, session.id, {
+      content: [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/bmp", data: "abc" },
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/unsupported media type/i);
+  });
+
+  it("rejects image blocks with empty data", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const res = await postMessage(app, session.id, {
+      content: [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "" },
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/non-empty base64 data/i);
+  });
+
+  it("rejects unknown content block types", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const res = await postMessage(app, session.id, {
+      content: [{ type: "video", url: "https://example.com/v.mp4" }],
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/unknown content block type/i);
+  });
+
+  it("rejects when neither text nor content is provided", async () => {
+    const { app, sessions } = createApp();
+    const session = sessions.create();
+
+    const res = await postMessage(app, session.id, {});
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/text or content required/i);
+  });
+
+  it("returns 404 for unknown session", async () => {
+    const { app } = createApp();
+
+    const res = await postMessage(app, "nonexistent", { text: "Hello" });
+    expect(res.status).toBe(404);
+  });
+
+  it("accepts all four supported image media types", async () => {
+    const { app, sessions } = createApp();
+
+    for (const mediaType of ["image/jpeg", "image/png", "image/gif", "image/webp"]) {
+      const session = sessions.create();
+      const res = await postMessage(app, session.id, {
+        content: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: mediaType, data: "abc123" },
+          },
+        ],
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+});

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -1,8 +1,59 @@
-import type { PermissionResponse, RewindFilesRequest, SSEEvent } from "@neeter/types";
+import type {
+  ContentBlock,
+  PermissionResponse,
+  RewindFilesRequest,
+  SSEEvent,
+  UserMessageContent,
+} from "@neeter/types";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { type Session, type SessionManager, sessionMeta } from "./session.js";
+import { extractText, type Session, type SessionManager, sessionMeta } from "./session.js";
 import { type MessageTranslator, sseEncode, streamSession } from "./translator.js";
+
+const VALID_IMAGE_MEDIA_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+
+function validateContentBlocks(
+  blocks: unknown[],
+): { ok: true; content: ContentBlock[] } | { ok: false; error: string } {
+  if (blocks.length === 0) return { ok: false, error: "Content array must not be empty" };
+  const validated: ContentBlock[] = [];
+  for (const block of blocks) {
+    const b = block as Record<string, unknown>;
+    switch (b.type) {
+      case "text": {
+        if (typeof b.text !== "string" || !b.text.trim()) {
+          return { ok: false, error: "Text blocks must have non-empty text" };
+        }
+        validated.push({ type: "text", text: b.text });
+        break;
+      }
+      case "image": {
+        const src = b.source as Record<string, unknown> | undefined;
+        if (!src || src.type !== "base64") {
+          return { ok: false, error: "Image blocks must have a base64 source" };
+        }
+        if (!VALID_IMAGE_MEDIA_TYPES.has(src.media_type as string)) {
+          return { ok: false, error: `Unsupported media type: ${src.media_type}` };
+        }
+        if (typeof src.data !== "string" || !src.data) {
+          return { ok: false, error: "Image blocks must have non-empty base64 data" };
+        }
+        validated.push({
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: src.media_type as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
+            data: src.data,
+          },
+        });
+        break;
+      }
+      default:
+        return { ok: false, error: `Unknown content block type: ${b.type}` };
+    }
+  }
+  return { ok: true, content: validated };
+}
 
 const PERSISTED_EVENTS = new Set([
   "text_delta",
@@ -29,7 +80,7 @@ export function createAgentRouter<TCtx>(config: {
 }): Hono {
   const { sessions, translator, basePath = "/api" } = config;
   const app = new Hono();
-  const pendingUserMessages = new WeakMap<Session<TCtx>, string[]>();
+  const pendingUserMessages = new WeakMap<Session<TCtx>, UserMessageContent[]>();
 
   app.use(`${basePath}/*`, cors({ origin: "*" }));
 
@@ -118,21 +169,34 @@ export function createAgentRouter<TCtx>(config: {
     const session = sessions.get(c.req.param("id"));
     if (!session) return c.json({ error: "Session not found" }, 404);
 
-    const body = await c.req.json<{ text: string }>();
-    if (!body.text?.trim()) return c.json({ error: "Message text required" }, 400);
+    const body = await c.req.json<{ text?: string; content?: unknown[] }>();
 
-    const text = body.text.trim();
-    session.pushMessage(text);
+    let messageContent: UserMessageContent;
+    if (Array.isArray(body.content)) {
+      const result = validateContentBlocks(body.content);
+      if (!result.ok) return c.json({ error: result.error }, 400);
+      messageContent = result.content;
+    } else if (body.text?.trim()) {
+      messageContent = body.text.trim();
+    } else {
+      return c.json({ error: "Message text or content required" }, 400);
+    }
+
+    session.pushMessage(messageContent);
+
+    const text = extractText(messageContent);
+    const persistData: Record<string, unknown> = { text };
+    if (typeof messageContent !== "string") persistData.content = messageContent;
 
     const store = sessions.getStore();
     if (store && session.sdkSessionId) {
       void store.save(session.sdkSessionId, {
         meta: sessionMeta(session),
-        events: [{ event: "user_message", data: JSON.stringify({ text }) }],
+        events: [{ event: "user_message", data: JSON.stringify(persistData) }],
       });
     } else if (store) {
       const pending = pendingUserMessages.get(session) ?? [];
-      pending.push(text);
+      pending.push(messageContent);
       pendingUserMessages.set(session, pending);
     }
 
@@ -150,10 +214,12 @@ export function createAgentRouter<TCtx>(config: {
           if (evt.event === "session_init") {
             const pending = pendingUserMessages.get(session);
             if (pending) {
-              const userEvents = pending.map((text) => ({
-                event: "user_message",
-                data: JSON.stringify({ text }),
-              }));
+              const userEvents = pending.map((content) => {
+                const text = extractText(content);
+                const data: Record<string, unknown> = { text };
+                if (typeof content !== "string") data.content = content;
+                return { event: "user_message", data: JSON.stringify(data) };
+              });
               void store.save(session.sdkSessionId, {
                 meta: sessionMeta(session),
                 events: [...userEvents, evt],

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -1,3 +1,4 @@
+import type { ContentBlock } from "@neeter/types";
 import { describe, expect, it, vi } from "vitest";
 
 let lastQueryOptions: Record<string, unknown> | undefined;
@@ -11,7 +12,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   },
 }));
 
-import { SessionManager } from "./session.js";
+import { extractText, SessionManager } from "./session.js";
 
 function createManager(
   factory?: (original?: { context: { n: number } }) => {
@@ -200,5 +201,71 @@ describe("SessionManager.listHistory", () => {
     const history = await mgr.listHistory();
     expect(history[0].sdkSessionId).toBe("sdk-new");
     expect(history[1].sdkSessionId).toBe("sdk-old");
+  });
+});
+
+describe("pushMessage with content arrays", () => {
+  it("captures firstPrompt from text blocks in a content array", async () => {
+    const mgr = createManager();
+    const session = mgr.create();
+    session.sdkSessionId = "sdk-mm";
+
+    const content: ContentBlock[] = [
+      { type: "text", text: "Describe this diagram" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "iVBOR..." },
+      },
+    ];
+    session.pushMessage(content);
+
+    const history = await mgr.listHistory();
+    expect(history[0].description).toBe("Describe this diagram");
+  });
+
+  it("still captures firstPrompt from a plain string", async () => {
+    const mgr = createManager();
+    const session = mgr.create();
+    session.sdkSessionId = "sdk-txt";
+    session.pushMessage("Hello world");
+
+    const history = await mgr.listHistory();
+    expect(history[0].description).toBe("Hello world");
+  });
+
+  it("joins multiple text blocks with a space", () => {
+    const mgr = createManager();
+    const session = mgr.create();
+
+    const content: ContentBlock[] = [
+      { type: "text", text: "Part one" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
+      { type: "text", text: "Part two" },
+    ];
+    session.pushMessage(content);
+
+    expect(session.firstPrompt).toBe("Part one Part two");
+  });
+});
+
+describe("extractText", () => {
+  it("returns the string as-is for string content", () => {
+    expect(extractText("Hello")).toBe("Hello");
+  });
+
+  it("joins text blocks from a content array", () => {
+    const content: ContentBlock[] = [
+      { type: "text", text: "First" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "x" } },
+      { type: "text", text: "Second" },
+    ];
+    expect(extractText(content)).toBe("First Second");
+  });
+
+  it("returns empty string for image-only content", () => {
+    const content: ContentBlock[] = [
+      { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "x" } },
+    ];
+    expect(extractText(content)).toBe("");
   });
 });

--- a/packages/server/src/session.ts
+++ b/packages/server/src/session.ts
@@ -7,17 +7,33 @@ import {
   query,
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
-import type { SessionHistoryEntry, SessionStore, SSEEvent, UserQuestion } from "@neeter/types";
+import type {
+  SessionHistoryEntry,
+  SessionStore,
+  SSEEvent,
+  TextBlock,
+  UserMessageContent,
+  UserQuestion,
+} from "@neeter/types";
 import { PermissionGate } from "./permission-gate.js";
 import { PushChannel } from "./push-channel.js";
 
-function userMessage(content: string): SDKUserMessage {
+function userMessage(content: UserMessageContent): SDKUserMessage {
   return {
     type: "user",
     message: { role: "user", content },
     parent_tool_use_id: null,
     session_id: "",
   };
+}
+
+/** Extract the text portion from a `UserMessageContent` value. */
+export function extractText(content: UserMessageContent): string {
+  if (typeof content === "string") return content;
+  return content
+    .filter((b): b is TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join(" ");
 }
 
 /** Configuration returned by the `SessionManager` factory for each new session. */
@@ -67,7 +83,7 @@ export interface Session<TCtx> {
   cwd?: string;
   enableFileCheckpointing?: boolean;
   context: TCtx;
-  pushMessage(text: string): void;
+  pushMessage(content: UserMessageContent): void;
   messageIterator: Query;
   permissionGate: PermissionGate;
   abort(): void;
@@ -279,11 +295,11 @@ export class SessionManager<TCtx> {
       enableFileCheckpointing: !!init.enableFileCheckpointing,
       context: init.context,
       replayGate: !!extraQueryOptions?.resume,
-      pushMessage: (text: string) => {
+      pushMessage: (content: UserMessageContent) => {
         session.replayGate = false;
         session.lastActivityAt = Date.now();
-        if (!session.firstPrompt) session.firstPrompt = text;
-        channel.push(userMessage(text));
+        if (!session.firstPrompt) session.firstPrompt = extractText(content);
+        channel.push(userMessage(content));
       },
       messageIterator,
       permissionGate,

--- a/packages/server/src/translator.test.ts
+++ b/packages/server/src/translator.test.ts
@@ -766,6 +766,59 @@ describe("MessageTranslator", () => {
     const events = t.translate({ type: "unknown_type" }, session);
     expect(events).toEqual([]);
   });
+
+  it("emits checkpoint for user messages with content-array (text + image blocks)", () => {
+    const t = new MessageTranslator();
+    const events = t.translate(
+      {
+        type: "user",
+        uuid: "cp-uuid-multimodal",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this image" },
+            {
+              type: "image",
+              source: { type: "base64", media_type: "image/png", data: "iVBOR..." },
+            },
+          ],
+        },
+      },
+      session,
+    );
+    expect(events).toEqual([
+      { event: "checkpoint", data: JSON.stringify({ userMessageUuid: "cp-uuid-multimodal" }) },
+    ]);
+  });
+
+  it("does not emit checkpoint for tool-result arrays (unchanged behavior)", () => {
+    const t = new MessageTranslator();
+    t.translate(
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "t-tr", name: "Bash", input: {} }] },
+      },
+      session,
+    );
+    const events = t.translate(
+      {
+        type: "user",
+        uuid: "cp-uuid-tool-result",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t-tr", content: "done" }],
+        },
+      },
+      session,
+    );
+    // Should get tool_result but NOT a checkpoint
+    expect(events).toEqual([
+      {
+        event: "tool_result",
+        data: JSON.stringify({ toolUseId: "t-tr", result: "done", isError: false }),
+      },
+    ]);
+  });
 });
 
 describe("sseEncode", () => {

--- a/packages/server/src/translator.ts
+++ b/packages/server/src/translator.ts
@@ -167,9 +167,12 @@ export class MessageTranslator<TCtx> {
 
       case "user": {
         const msg = (message as { message?: { role: string; content: unknown } }).message;
-        // Only emit checkpoints for real user messages (string content),
-        // not tool-result round-trips (array content with tool_result blocks).
-        const isToolResult = Array.isArray(msg?.content);
+        // Emit checkpoints for real user messages (string or content-array with
+        // text/image blocks), not tool-result round-trips (content-array with
+        // tool_result blocks).
+        const isToolResult =
+          Array.isArray(msg?.content) &&
+          (msg.content as Array<{ type: string }>).some((b) => b.type === "tool_result");
         const uuid = message.uuid as string | undefined;
         if (uuid && !isToolResult) {
           events.push({

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -13,6 +13,7 @@ pnpm add @neeter/types
 ## What's inside
 
 - **SSE protocol** — `SSEEvent`, `CustomEvent<T>`, `SessionInitEvent`
+- **Content blocks** — `TextBlock`, `ImageBlock`, `ContentBlock`, `UserMessageContent`, `Base64ImageSource`
 - **Chat messages** — `ChatMessage`, `ToolCallInfo`, `ToolCallPhase`
 - **Permissions** — `PermissionRequest`, `PermissionResponse`, `ToolApprovalRequest`, `ToolApprovalResponse`, `UserQuestion`, `UserQuestionRequest`, `UserQuestionResponse`
 - **Persistence** — `SessionStore`, `SessionRecord`, `SessionHistoryEntry`

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,6 +30,29 @@ export interface SessionHistoryEntry {
   lastActivityAt: number;
 }
 
+// --- Content Blocks (multimodal messages) ---
+
+export interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+export interface Base64ImageSource {
+  type: "base64";
+  media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+  data: string;
+}
+
+export interface ImageBlock {
+  type: "image";
+  source: Base64ImageSource;
+}
+
+export type ContentBlock = TextBlock | ImageBlock;
+
+/** Content for a user message — plain string or array of text/image blocks. */
+export type UserMessageContent = string | ContentBlock[];
+
 // --- Chat Store ---
 
 export type ToolCallPhase = "pending" | "streaming_input" | "running" | "complete" | "error";


### PR DESCRIPTION
## Summary

Closes #32

- Widen the message pipeline to accept `content: ContentBlock[]` (text + base64 image blocks) alongside plain `text` strings
- Add content block types (`TextBlock`, `ImageBlock`, `Base64ImageSource`, `ContentBlock`, `UserMessageContent`) to `@neeter/types` and re-export from `@neeter/server`
- Add `extractText()` helper and input validation (`validateContentBlocks`) in the router
- Fix translator checkpoint logic to distinguish multimodal user messages from tool-result arrays

## Test plan

- [x] 12 new router tests covering text messages, content arrays, validation (empty array, empty text, invalid media types, missing data, unknown block types, all 4 media types)
- [x] 5 new session tests (pushMessage with content arrays, extractText helper)
- [x] 2 new translator tests (checkpoint for multimodal user messages, tool-result suppression unchanged)
- [x] All 182 tests passing
- [x] Manual E2E smoke test: sent screenshot through server, agent correctly described image content