### PR TITLE
fix(docs): use static Orama search for GitHub Pages

### DIFF
--- a/apps/docs/app/components/provider.tsx
+++ b/apps/docs/app/components/provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { RootProvider } from "fumadocs-ui/provider/next";
+import type { ReactNode } from "react";
+import SearchDialog from "@/app/components/search";
+
+export function Provider({ children }: { children: ReactNode }) {
+  return (
+    <RootProvider
+      search={{
+        SearchDialog,
+      }}
+    >
+      {children}
+    </RootProvider>
+  );
+}

--- a/apps/docs/app/components/search.tsx
+++ b/apps/docs/app/components/search.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { create } from "@orama/orama";
+import { useDocsSearch } from "fumadocs-core/search/client";
+import {
+  SearchDialog,
+  SearchDialogClose,
+  SearchDialogContent,
+  SearchDialogHeader,
+  SearchDialogIcon,
+  SearchDialogInput,
+  SearchDialogList,
+  SearchDialogOverlay,
+  type SharedProps,
+} from "fumadocs-ui/components/dialog/search";
+
+function initOrama() {
+  return create({
+    schema: { _: "string" },
+    language: "english",
+  });
+}
+
+export default function StaticSearchDialog(props: SharedProps) {
+  const { search, setSearch, query } = useDocsSearch({
+    type: "static",
+    from: "/neeter/api/search",
+    initOrama,
+  });
+
+  return (
+    <SearchDialog search={search} onSearchChange={setSearch} isLoading={query.isLoading} {...props}>
+      <SearchDialogOverlay />
+      <SearchDialogContent>
+        <SearchDialogHeader>
+          <SearchDialogIcon />
+          <SearchDialogInput />
+          <SearchDialogClose />
+        </SearchDialogHeader>
+        <SearchDialogList items={query.data !== "empty" ? query.data : null} />
+      </SearchDialogContent>
+    </SearchDialog>
+  );
+}

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,6 +1,6 @@
 import "./global.css";
-import { RootProvider } from "fumadocs-ui/provider/next";
 import type { ReactNode } from "react";
+import { Provider } from "@/app/components/provider";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -12,7 +12,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           minHeight: "100vh",
         }}
       >
-        <RootProvider>{children}</RootProvider>
+        <Provider>{children}</Provider>
       </body>
     </html>
   );

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,9 +1,7 @@
 ---
 title: Introduction
-description: A React + Hono toolkit that puts a browser UI on the Claude Agent SDK
+description: A React + Hono toolkit that puts a browser UI on the Claude Agent SDK — the same agentic framework that powers Claude Code. Streams tool calls, file edits, permissions, and multi-turn sessions over SSE into ready-made React components.
 ---
-
-A React + Hono toolkit that puts a browser UI on the [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) — the same agentic framework that powers Claude Code. Streams tool calls, file edits, permissions, and multi-turn sessions over SSE into ready-made React components.
 
 <Img src="/images/hero.png" alt="A multi-turn conversation with streaming tool calls, built with neeter" width={600} />
 

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,6 +8,7 @@
     "preview": "npx serve out"
   },
   "dependencies": {
+    "@orama/orama": "^3.1.18",
     "fumadocs-core": "^16.2.0",
     "fumadocs-mdx": "^14.1.0",
     "fumadocs-ui": "^16.2.0",
@@ -16,11 +17,11 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.1",
     "@types/mdx": "^2.0.13",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "postcss": "^8.5.6",
-    "@tailwindcss/postcss": "^4.2.1",
     "tailwindcss": "^4.2.1",
     "typescript": "~5.9.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   apps/docs:
     dependencies:
+      '@orama/orama':
+        specifier: ^3.1.18
+        version: 3.1.18
       fumadocs-core:
         specifier: ^16.2.0
         version: 16.6.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.575.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
@@ -71,7 +74,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: latest
-        version: 0.2.53(zod@4.3.6)
+        version: 0.2.56(zod@4.3.6)
       '@hono/node-server':
         specifier: ^1.14.3
         version: 1.19.9(hono@4.12.2)
@@ -144,7 +147,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: latest
-        version: 0.2.53(zod@4.3.6)
+        version: 0.2.56(zod@4.3.6)
       '@hono/node-server':
         specifier: ^1.14.3
         version: 1.19.9(hono@4.12.2)
@@ -285,6 +288,12 @@ packages:
 
   '@anthropic-ai/claude-agent-sdk@0.2.53':
     resolution: {integrity: sha512-0w67qV9e+tDfjFjxq0EzLAabsGI4bWyKnJswWDp0OMOKaS7CmVWHMwaufqMq4DDble3CrC+OFVUVafk9vL+Q3g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@anthropic-ai/claude-agent-sdk@0.2.56':
+    resolution: {integrity: sha512-EpDeAUlhFIAWOfps7fWdAAmJgMvqmISODyPFVbvgfL17EHFTHF1cpPiZQEQYjzUcUXE8nvcVxQlBzuMukHqItA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -3080,6 +3089,20 @@ snapshots:
   '@alloc/quick-lru@5.2.0': {}
 
   '@anthropic-ai/claude-agent-sdk@0.2.53(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  '@anthropic-ai/claude-agent-sdk@0.2.56(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Switch docs search from fetch-based client to static Orama client — fetch requests to `/api/search` 404 on static export
- Explicitly set `from: "/neeter/api/search"` since the static client defaults to `/api/search` and does not respect Next.js `basePath`
- Move expanded intro description into frontmatter to fix duplicate text on the Introduction page

## Test plan
- [x] `pnpm check` / `pnpm build` / `pnpm test` (182 tests) / `pnpm docs:build` (11 pages) all pass
- [x] Search confirmed working in browser (dev server) — returns results for queries like "widget"